### PR TITLE
BinDeps integration

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.2-
+BinDeps

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,37 @@
+using BinDeps
+
+@BinDeps.setup
+
+cvode = library_dependency("libsundials_cvode")
+cvodes = library_dependency("libsundials_cvodes")
+ida = library_dependency("libsundials_ida")
+idas = library_dependency("libsundials_idas")
+kinsol = library_dependency("libsundials_kinsol")
+nvecserial = library_dependency("libsundials_nvecserial")
+sundialslibs = [cvode, cvodes, ida, idas, kinsol, nvecserial]
+
+sundialsver = "sundials-2.5.0"
+provides(Sources, URI("http://computation.llnl.gov/casc/sundials/download/code/$sundialsver.tar.gz"), sundialslibs)
+
+provides(Binaries, URI("http://sourceforge.net/projects/juliadeps-win/files/$sundialsver-$(Sys.MACHINE).7z"),
+    sundialslibs, os = :Windows)
+
+prefix = joinpath(BinDeps.depsdir(cvode),"usr")
+srcdir = joinpath(BinDeps.depsdir(cvode),"src",sundialsver) 
+
+provides(SimpleBuild,
+    (@build_steps begin
+        GetSources(cvode)
+        @build_steps begin
+            ChangeDirectory(srcdir)
+            `./configure --prefix=$prefix --enable-shared`
+            `make install`
+        end
+    end), sundialslibs)
+
+@BinDeps.install [:libsundials_cvode => :libsundials_cvode,
+                  :libsundials_cvodes => :libsundials_cvodes,
+                  :libsundials_ida => :libsundials_ida,
+                  :libsundials_idas => :libsundials_idas,
+                  :libsundials_kinsol => :libsundials_kinsol,
+                  :libsundials_nvecserial => :libsundials_nvecserial]

--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -1,5 +1,10 @@
 module Sundials
 
+if isfile(joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl"))
+    include("../deps/deps.jl")
+else
+    error("Sundials not properly installed. Please run Pkg.build(\"Sundials\")")
+end
 
 ##################################################################
 #
@@ -9,18 +14,18 @@ module Sundials
 
 typealias __builtin_va_list Ptr{:Void}
 
-shlib = :libsundials_nvecserial
+shlib = libsundials_nvecserial
 include("nvector.jl")
-shlib = :libsundials_cvode
+shlib = libsundials_cvode
 include("libsundials.jl")
 include("cvode.jl")
-shlib = :libsundials_cvodes
+shlib = libsundials_cvodes
 include("cvodes.jl")
-shlib = :libsundials_ida
+shlib = libsundials_ida
 include("ida.jl")
-shlib = :libsundials_idas
+shlib = libsundials_idas
 include("idas.jl")
-shlib = :libsundials_kinsol
+shlib = libsundials_kinsol
 include("kinsol.jl")
 
 include("constants.jl")
@@ -193,7 +198,7 @@ IDAQuadReInit(mem, yQ0::Vector{realtype}) =
 ##################################################################
 
 
-@c Int32 KINSetUserData (Ptr{:None},Any) :libsundials_kinsol  ## needed to allow passing a Function through the user data
+@c Int32 KINSetUserData (Ptr{:None},Any) libsundials_kinsol  ## needed to allow passing a Function through the user data
 
 function kinsolfun(y::N_Vector, fy::N_Vector, userfun::Function)
     y = asarray(y)
@@ -229,7 +234,7 @@ function kinsol(f::Function, y0::Vector{Float64})
     return y
 end
 
-@c Int32 CVodeSetUserData (Ptr{:None},Any) :libsundials_cvode  ## needed to allow passing a Function through the user data
+@c Int32 CVodeSetUserData (Ptr{:None},Any) libsundials_cvode  ## needed to allow passing a Function through the user data
 
 function odefun(t::Float64, y::N_Vector, yp::N_Vector, userfun::Function)
     y = Sundials.asarray(y)
@@ -264,7 +269,7 @@ function ode(f::Function, y0::Vector{Float64}, t::Vector{Float64}; reltol::Float
     return yres
 end
 
-@c Int32 IDASetUserData (Ptr{:None},Any) :libsundials_ida  ## needed to allow passing a Function through the user data
+@c Int32 IDASetUserData (Ptr{:None},Any) libsundials_ida  ## needed to allow passing a Function through the user data
 
 function daefun(t::Float64, y::N_Vector, yp::N_Vector, r::N_Vector, userfun::Function)
     y = Sundials.asarray(y) 


### PR DESCRIPTION
Builds from source on Unix, downloads binaries on Windows, basic functionality appears to work.
Haven't tested this on Mac, could eventually use a Homebrew formula and supply bottles for users who don't have compilers installed.

Fixes part of #6, would be a good idea to turn the examples into tests, set up Travis, etc.

The Windows binaries were built from Cygwin as follows

```
../configure --enable-shared --host=i686-w64-mingw32 --prefix=$PWD/usr
make LDFLAGS="-no-undefined -avoid-version"
make LDFLAGS="-no-undefined -avoid-version" install
```

for 32 bit, or replacing `i686` with `x86_64` for 64 bit.
