### PR TITLE
Cast nvlength to int32

### DIFF
--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -44,9 +44,8 @@ include("constants.jl")
 #
 ##################################################################
 
-nvlength(x::N_Vector) = unsafe_load(unsafe_load(convert(Ptr{Ptr{Int64}}, x)))
-asarray(x::N_Vector) = pointer_to_array(N_VGetArrayPointer_Serial(x),
-                                         (int(nvlength(x)),))
+nvlength(x::N_Vector) = unsafe_load(unsafe_load(convert(Ptr{Ptr{Int}}, x)))
+asarray(x::N_Vector) = pointer_to_array(N_VGetArrayPointer_Serial(x), (nvlength(x),))
 asarray(x::Vector{realtype}) = x
 asarray(x::Ptr{realtype}, dims::Tuple) = pointer_to_array(x, dims)
 asarray(x::N_Vector, dims::Tuple) = reinterpret(realtype, asarray(x), dims)


### PR DESCRIPTION
Fixes the following error on 32-bit systems:

ERROR: no method pointer_to_array(Ptr{Float64},(Int64,))

when calling Sundials.asarray

Tested by running the ida example on this configuration:

```
$ uname -a
Linux lab15-lenovo 3.2.0-67-generic-pae #101-Ubuntu SMP Tue Jul 15 18:04:54 UTC 2014 i686 i686     i386 GNU/Linux
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=12.04
DISTRIB_CODENAME=precise
DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"
```

And on this other one:

```
$ uname -a
Linux ignacio-laptop 3.13.0-33-generic #58-Ubuntu SMP Tue Jul 29 16:45:05 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.1 LTS"
```
