### PR TITLE
Make nvlength return Int

### DIFF
--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -44,7 +44,7 @@ include("constants.jl")
 #
 ##################################################################
 
-nvlength(x::N_Vector) = unsafe_load(unsafe_load(convert(Ptr{Ptr{Int64}}, x)))
+nvlength(x::N_Vector) = unsafe_load(unsafe_load(convert(Ptr{Ptr{Int}}, x)))
 asarray(x::N_Vector) = pointer_to_array(N_VGetArrayPointer_Serial(x), (nvlength(x),))
 asarray(x::Vector{realtype}) = x
 asarray(x::Ptr{realtype}, dims::Tuple) = pointer_to_array(x, dims)


### PR DESCRIPTION
Fixes the following error on 32-bit systems:

ERROR: no method pointer_to_array(Ptr{Float64},(Int64,))

when calling Sundials.asarray
