### PR TITLE
Add KINSOL DiffEq interface

### DIFF
--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -45,7 +45,7 @@ end
 using Sundials_jll
 
 export solve,
-    SundialsODEAlgorithm, SundialsDAEAlgorithm, ARKODE, CVODE_BDF, CVODE_Adams, IDA
+    SundialsODEAlgorithm, SundialsDAEAlgorithm, ARKODE, CVODE_BDF, CVODE_Adams, IDA, KINSOL
 
 # some definitions from the system C headers wrapped into the types_and_consts.jl
 const DBL_MAX = prevfloat(Inf)

--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -364,9 +364,49 @@ Base.@pure function IDA(;
     )
 end
 
+struct KINSOL{LinearSolver} <: SundialsNonlinearSolveAlgorithm{LinearSolver}
+    jac_upper::Int
+    jac_lower::Int
+    userdata::Any
+end
+Base.@pure function KINSOL(;
+    linear_solver = :Dense,
+    jac_upper = 0,
+    jac_lower = 0,
+    userdata = nothing,
+)
+    if linear_solver == :Band && (jac_upper == 0 || jac_lower == 0)
+        error("Banded solver must set the jac_upper and jac_lower")
+    end
+    if !(
+        linear_solver in (
+            :None,
+            :Diagonal,
+            :Dense,
+            :LapackDense,
+            :Band,
+            :LapackBand,
+            :BCG,
+            :GMRES,
+            :FGMRES,
+            :PCG,
+            :TFQMR,
+            :KLU,
+        )
+    )
+        error("Linear solver choice not accepted.")
+    end
+    KINSOL{linear_solver}(
+        jac_upper,
+        jac_lower,
+        userdata,
+    )
+end
+
 method_choice(alg::SundialsODEAlgorithm{Method}) where {Method} = Method
 method_choice(alg::SundialsDAEAlgorithm) = :Newton
 linear_solver(
     alg::SundialsODEAlgorithm{Method, LinearSolver},
 ) where {Method, LinearSolver} = LinearSolver
 linear_solver(alg::SundialsDAEAlgorithm{LinearSolver}) where {LinearSolver} = LinearSolver
+linear_solver(alg::SundialsNonlinearSolveAlgorithm{LinearSolver}) where {LinearSolver} = LinearSolver

--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -3,6 +3,7 @@
 # Abstract Types
 abstract type SundialsODEAlgorithm{Method, LinearSolver} <: DiffEqBase.AbstractODEAlgorithm end
 abstract type SundialsDAEAlgorithm{LinearSolver} <: DiffEqBase.AbstractDAEAlgorithm end
+abstract type SundialsNonlinearSolveAlgorithm{LinearSolver} end
 
 # ODE Algorithms
 struct CVODE_BDF{Method, LinearSolver, P, PS} <: SundialsODEAlgorithm{Method, LinearSolver}

--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -375,9 +375,6 @@ Base.@pure function KINSOL(;
     jac_lower = 0,
     userdata = nothing,
 )
-    if linear_solver == :Band && (jac_upper == 0 || jac_lower == 0)
-        error("Banded solver must set the jac_upper and jac_lower")
-    end
     if !(
         linear_solver in (
             :None,

--- a/test/kinsol_banded.jl
+++ b/test/kinsol_banded.jl
@@ -6,3 +6,27 @@ end
 x = ones(5)
 @test Sundials.kinsol(f!, x, linear_solver = :Band, jac_upper = 0, jac_lower = 0) ==
       Sundials.kinsol(f!, x)
+
+function f_iip(du, u, p, t)
+    @. du = sin(u) + u^3
+end
+function f_iip(du, u, p)
+    @. du = sin(u) + u^3
+end
+function f_oop(u, p, t)
+    return @. sin(u) + u^3
+end
+function f_oop(u, p)
+    return @. sin(u) + u^3
+end
+
+#Testing KINSOL()
+u0 = ones(5)
+prob_iip = SteadyStateProblem(f_iip, u0)
+prob_oop = SteadyStateProblem(f_oop, u0)
+@test solve(prob_iip, KINSOL()) == solve(prob_iip, KINSOL(linear_solver=:Band, jac_upper=0, jac_lower=0))
+@test solve(prob_oop, KINSOL()) == solve(prob_oop, KINSOL(linear_solver=:Band, jac_upper=0, jac_lower=0))
+prob_iip = NonlinearProblem(f_iip, u0)
+prob_oop = NonlinearProblem(f_oop, u0)
+@test solve(prob_iip, KINSOL()) == solve(prob_iip, KINSOL(linear_solver=:Band, jac_upper=0, jac_lower=0))
+@test solve(prob_oop, KINSOL()) == solve(prob_oop, KINSOL(linear_solver=:Band, jac_upper=0, jac_lower=0))


### PR DESCRIPTION
Hi,

I have added KINSOL interface similar to DiffEq.
MWE:

```
julia> function f(du,u,p,t)
         du[1] = 2 - 2u[1]
         du[2] = u[1] - 4u[2]
       end
f (generic function with 3 methods)

julia> u0 = zeros(2)
2-element Array{Float64,1}:
 0.0
 0.0

julia> prob = SteadyStateProblem(f,u0)
SteadyStateProblem with uType Array{Float64,1}. In-place: true
u0: [0.0, 0.0]

julia> sol = solve(prob,KINSOL())
u: 2-element Array{Float64,1}:
 1.0
 0.25
```
@ChrisRackauckas, please review.