### PR TITLE
Fix for IDA preconditioner solve function signature (remove 'ls' argument)

### DIFF
--- a/src/common_interface/function_types.jl
+++ b/src/common_interface/function_types.jl
@@ -244,7 +244,6 @@ function idaprecsolve(
     z::N_Vector,
     gamma::Float64,
     delta::Float64,
-    lr::Int,
     fj::AbstractFunJac,
 )
     fj.prec(
@@ -257,7 +256,6 @@ function idaprecsolve(
         convert(Vector, resid),
         gamma,
         delta,
-        lr,
     )
     return IDA_SUCCESS
 end

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1249,7 +1249,7 @@ function DiffEqBase.__init(
     end
 
     if alg.prec !== nothing
-        function getpercfun(::T) where {T}
+        function getprecfun(::T) where {T}
             @cfunction(
                 idaprecsolve,
                 Cint,
@@ -1262,12 +1262,11 @@ function DiffEqBase.__init(
                     N_Vector,
                     Float64,
                     Float64,
-                    Int,
                     Ref{T},
                 )
             )
         end
-        precfun = getpercfun(userfun)
+        precfun = getprecfun(userfun)
 
         function getpsetupfun(::T) where {T}
             @cfunction(

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -31,13 +31,13 @@ sol11 = solve(prob, IDA(linear_solver = :Dense))
 # Test identity preconditioner
 global prec_used = false
 global psetup_used = false
-prec = (z, r, p, t, y, fy, resid, gamma, delta, lr) -> (global prec_used = true; z .= r)
+prec = (z, r, p, t, y, fy, resid, gamma, delta) -> (global prec_used = true; z .= r)
 psetup = (p, t, resid, u, du, gamma) -> (global psetup_used = true)
 @info "GMRES for identity preconditioner"
-sol4 = solve(prob, IDA(linear_solver = :GMRES, prec_side = 3, prec = prec))
+sol4 = solve(prob, IDA(linear_solver = :GMRES, prec_side = 1, prec = prec))  # IDA requires left preconditioning (prec_side = 1)
 @test prec_used
 @info "GMRES with pset"
-sol4 = solve(prob, IDA(linear_solver = :GMRES, prec_side = 3, prec = prec, psetup = psetup))
+sol4 = solve(prob, IDA(linear_solver = :GMRES, prec_side = 1, prec = prec, psetup = psetup)) # IDA requires left preconditioning (prec_side = 1)
 @test psetup_used
 
 @info "IDA with saveat"


### PR DESCRIPTION
Issue https://github.com/SciML/Sundials.jl/issues/317

Prototype is:

https://github.com/LLNL/sundials/blob/v5.3.0/include/idas/idas_ls.h

typedef int (*IDALsPrecSolveFn)(realtype tt, N_Vector yy,
                                N_Vector yp, N_Vector rr,
                                N_Vector rvec, N_Vector zvec,
                                realtype c_j, realtype delta,
                                void *user_data);

Not sure why the tests still passed with the spurious 'ls' argument
(a larger example failed though).