### PR TITLE
Remove IDA 'prec_side' option, as IDA only supports left preconditioning

### DIFF
--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -431,6 +431,8 @@ linearsolver - This is the linear solver which is used in the Newton iterations.
 :TFQMR - A TFQMR method.
 :KLU - A sparse factorization method. Requires that the user specifies a Jacobian. The Jacobian must be set as a sparse matrix in the ODEProblem type.
 
+Note that the preconditioner for iterative linear solvers (if supplied) should be a left preconditioner. 
+
 Example:
 
 IDA() # Newton + Dense solver
@@ -452,7 +454,7 @@ IDA(;linear_solver=:Dense,jac_upper=0,jac_lower=0,krylov_dim=0,
     use_linesearch_ic = true,
     max_convergence_failures = 10,
     init_all = false,
-    prec = nothing, psetup = nothing, prec_side = 0)
+    prec = nothing, psetup = nothing)
 """
 struct IDA{LinearSolver, P, PS} <: SundialsDAEAlgorithm{LinearSolver}
     jac_upper::Int
@@ -472,7 +474,6 @@ struct IDA{LinearSolver, P, PS} <: SundialsDAEAlgorithm{LinearSolver}
     init_all::Bool
     prec::P
     psetup::PS
-    prec_side::Int
 end
 Base.@pure function IDA(;
     linear_solver = :Dense,
@@ -493,7 +494,6 @@ Base.@pure function IDA(;
     max_convergence_failures = 10,
     prec = nothing,
     psetup = nothing,
-    prec_side = 0,
 )
     if linear_solver == :Band && (jac_upper == 0 || jac_lower == 0)
         error("Banded solver must set the jac_upper and jac_lower")
@@ -534,7 +534,6 @@ Base.@pure function IDA(;
         init_all,
         prec,
         psetup,
-        prec_side,
     )
 end
 """

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1174,6 +1174,7 @@ function DiffEqBase.__init(
     #flag = IDASetMaxBacksIC(mem,alg.max_num_backs_ic) # Needs newer version?
     flag = IDASetLineSearchOffIC(mem, alg.use_linesearch_ic)
 
+    prec_side = isnothing(alg.prec) ? 0 : 1  # IDA only supports left preconditioning (prec_side = 1)
     if LinearSolver in (:Dense, :LapackDense)
         nojacobian = false
         A = SUNDenseMatrix(length(u0), length(u0))
@@ -1197,23 +1198,23 @@ function DiffEqBase.__init(
             _LS = LinSolHandle(LS, LapackBand())
         end
     elseif LinearSolver == :GMRES
-        LS = SUNLinSol_SPGMR(u0, alg.prec_side, alg.krylov_dim)
+        LS = SUNLinSol_SPGMR(u0, prec_side, alg.krylov_dim)
         _A = nothing
         _LS = LinSolHandle(LS, SPGMR())
     elseif LinearSolver == :FGMRES
-        LS = SUNLinSol_SPFGMR(u0, alg.prec_side, alg.krylov_dim)
+        LS = SUNLinSol_SPFGMR(u0, prec_side, alg.krylov_dim)
         _A = nothing
         _LS = LinSolHandle(LS, SPFGMR())
     elseif LinearSolver == :BCG
-        LS = SUNLinSol_SPBCGS(u0, alg.prec_side, alg.krylov_dim)
+        LS = SUNLinSol_SPBCGS(u0, prec_side, alg.krylov_dim)
         _A = nothing
         _LS = LinSolHandle(LS, SPBCGS())
     elseif LinearSolver == :PCG
-        LS = SUNLinSol_PCG(u0, alg.prec_side, alg.krylov_dim)
+        LS = SUNLinSol_PCG(u0, prec_side, alg.krylov_dim)
         _A = nothing
         _LS = LinSolHandle(LS, PCG())
     elseif LinearSolver == :TFQMR
-        LS = SUNLinSol_SPTFQMR(u0, alg.prec_side, alg.krylov_dim)
+        LS = SUNLinSol_SPTFQMR(u0, prec_side, alg.krylov_dim)
         _A = nothing
         _LS = LinSolHandle(LS, PTFQMR())
     elseif LinearSolver == :KLU

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -39,10 +39,10 @@ sol11 = solve(prob, IDA(linear_solver = :Dense))
 prec = (z, r, p, t, y, fy, resid, gamma, delta) -> (p.prec_used = true; z .= r)
 psetup = (p, t, resid, u, du, gamma) -> (p.psetup_used = true)
 @info "GMRES for identity preconditioner"
-sol4 = solve(prob, IDA(linear_solver = :GMRES, prec_side = 1, prec = prec))  # IDA requires left preconditioning (prec_side = 1)
+sol4 = solve(prob, IDA(linear_solver = :GMRES, prec = prec))
 @test p.prec_used
 @info "GMRES with pset"
-sol4 = solve(prob, IDA(linear_solver = :GMRES, prec_side = 1, prec = prec, psetup = psetup)) # IDA requires left preconditioning (prec_side = 1)
+sol4 = solve(prob, IDA(linear_solver = :GMRES, prec = prec, psetup = psetup))
 @test p.psetup_used
 
 @info "IDA with saveat"


### PR DESCRIPTION
NB: a potentially breaking change !

See https://github.com/SciML/Sundials.jl/issues/317 (not strictly required to fix this issue, but removes potential confusion
where 'prec_side' other than 1 could appear to work but give poor performance).

From the IDA docs:

"We note that some sundials solvers are designed to only work with left preconditioning
(ida and idas) and others with only right preconditioning (kinsol). While
it is possible to configure a sunlinsol spgmr object to use any of the preconditioning
options with these solvers, this use mode is not supported and may result
in inferior performance."