### PR TITLE
Remove double free

### DIFF
--- a/src/simple.jl
+++ b/src/simple.jl
@@ -83,8 +83,6 @@ function kinsol(
     strategy = KIN_NONE
     flag = @checkflag KINSol(kmem, y, strategy, scale, scale) true
 
-    empty!(kmem)
-
     return y
 end
 
@@ -181,7 +179,6 @@ function cvode!(
         c = c + 1
     end
 
-    empty!(mem)
     Sundials.SUNLinSolFree_Dense(LS)
     Sundials.SUNMatDestroy_Dense(A)
 
@@ -277,7 +274,6 @@ function idasol(
         ypres[k, :] = yp
     end
 
-    empty!(mem)
     Sundials.SUNLinSolFree_Dense(LS)
     Sundials.SUNMatDestroy_Dense(A)
 


### PR DESCRIPTION
The GC is already going to be freeing this so the `empty!` call is unnecessary. The bigger issue is that this can free the memory, and then the GC can try and free the memory, and if those collide it can segfault. `empty!` does have a check in there to try and make that not occur, but that seems to be failing with the newer Sundials binaries, so it's probably better/safer to just use the tie-in to the GC anyways.

Fixes https://github.com/SciML/Sundials.jl/issues/323