### PR TITLE
Delete overwriting function

### DIFF
--- a/lib/libsundials_api.jl
+++ b/lib/libsundials_api.jl
@@ -5108,10 +5108,6 @@ function KINSetSysFunc(kinmem, func::KINSysFn)
     ccall((:KINSetSysFunc, libsundials_kinsol), Cint, (KINMemPtr, KINSysFn), kinmem, func)
 end
 
-function KINSetSysFunc(kinmem, func::KINSysFn)
-    KINSetSysFunc(kinmem, func)
-end
-
 function KINGetWorkSpace(kinmem, lenrw, leniw)
     ccall((:KINGetWorkSpace, libsundials_kinsol), Cint, (KINMemPtr, Ptr{Clong}, Ptr{Clong}),
           kinmem, lenrw, leniw)


### PR DESCRIPTION
```julia
julia> using Sundials
[ Info: Precompiling Sundials [c3572dad-4567-51f8-b174-8c6c989267f4]
WARNING: Method definition KINSetSysFunc(Any, Ptr{Nothing}) in module Sundials at /home/chriselrod/.julia/packages/Sundials/639C2/lib/libsundials_api.jl:5107 overwritten at /home/chriselrod/.julia/packages/Sundials/639C2/lib/libsundials_api.jl:5111.
  ** incremental compilation may be fatally broken for this module **
```