### PR TITLE
Convert array to realtype

### DIFF
--- a/src/nvector_wrapper.jl
+++ b/src/nvector_wrapper.jl
@@ -57,7 +57,7 @@ function Base.convert(::Type{NVector}, v::Vector{T}) where {T <: Real}
                           realtype),
                   v))
 end
-Base.convert(::Type{NVector}, v::AbstractVector) = NVector(convert(Array, v))
+Base.convert(::Type{NVector}, v::AbstractVector) = NVector(convert(Vector{realtype}, v))
 Base.convert(::Type{NVector}, nv::NVector) = nv
 Base.convert(::Type{NVector}, nv::N_Vector) = NVector(nv)
 Base.convert(::Type{Vector{realtype}}, nv::NVector) = nv.v


### PR DESCRIPTION
NVector only supports realtype values it seems so calling this with an array of any other number type would fail.