### PR TITLE
fix Vector{Float64} vs Sundials.Nvector in initialize_dae

### DIFF
--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -197,7 +197,11 @@ end
 
 function DiffEqBase.initialize_dae!(integrator::IDAIntegrator,
                                     initializealg::IDADefaultInit)
-    integrator.f(integrator.tmp, integrator.du, integrator.u, integrator.p, integrator.t)
+    integrator.f(integrator.tmp.v,
+                 integrator.du.v,
+                 integrator.u.v,
+                 integrator.p,
+                 integrator.t)
     tstart, tend = integrator.sol.prob.tspan
     if any(abs.(integrator.tmp) .>= integrator.opts.reltol)
         if integrator.sol.prob.differential_vars === nothing && !integrator.alg.init_all

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -197,7 +197,7 @@ end
 
 function DiffEqBase.initialize_dae!(integrator::IDAIntegrator,
                                     initializealg::IDADefaultInit)
-    integrator.f(integrator.tmp.v,
+    integrator.f(integrator.tmp,
                  integrator.du.v,
                  integrator.u.v,
                  integrator.p,

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -81,7 +81,8 @@ du0 = [0.0] # inconsistant
 dae_prob = DAEProblem(f!, du0, u0, tspan; differential_vars = [true])
 sol = solve(dae_prob, IDA())
 
-function f!(res, du, u, p, t)
+# Vector Float64 to make sure Sundials.NVector isn't messing with stuff
+function f!(res::Vector{Float64}, du, u, p, t)
     res[1] = u[1] - 1.01
     return
 end


### PR DESCRIPTION
this was broken before, but more obviously broken after https://github.com/SciML/Sundials.jl/pull/401