### PR TITLE
clean up a lot of IDA to remove a lot of type parameters

### DIFF
--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -179,7 +179,6 @@ mutable struct IDAIntegrator{pType,
     tout::toutType
     tdir::Float64
     sizeu::NTuple{N, Int}
-    sizedu::NTuple{N, Int}
     u_modified::Bool
     tmp::Array{Float64, N}
     uprev::Array{Float64, N}

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -148,9 +148,7 @@ function (integrator::ARKODEIntegrator)(out,
     return idxs === nothing ? out : @view out[idxs]
 end
 
-mutable struct IDAIntegrator{uType,
-                             duType,
-                             pType,
+mutable struct IDAIntegrator{pType,
                              memType,
                              solType,
                              algType,
@@ -159,15 +157,13 @@ mutable struct IDAIntegrator{uType,
                              JType,
                              oType,
                              toutType,
-                             sizeType,
-                             sizeDType,
-                             tmpType,
                              LStype,
                              Atype,
                              CallbackCacheType,
-                             IA} <: AbstractSundialsIntegrator{IDA}
-    u::uType
-    du::duType
+                             IA,
+                             N} <: AbstractSundialsIntegrator{IDA}
+    u::Array{Float64, N}
+    du::Array{Float64, N}
     p::pType
     t::Float64
     tprev::Float64
@@ -182,17 +178,19 @@ mutable struct IDAIntegrator{uType,
     opts::oType
     tout::toutType
     tdir::Float64
-    sizeu::sizeType
-    sizedu::sizeDType
+    sizeu::NTuple{N, Int}
+    sizedu::NTuple{N, Int}
     u_modified::Bool
-    tmp::tmpType
-    uprev::tmpType
+    tmp::Array{Float64, N}
+    uprev::Array{Float64, N}
     flag::Cint
     just_hit_tstop::Bool
     event_last_time::Int
     vector_event_last_time::Int
     callback_cache::CallbackCacheType
     last_event_error::Float64
+    u_nvec::NVector
+    du_nvec::NVector
     initializealg::IA
 end
 
@@ -200,7 +198,7 @@ function (integrator::IDAIntegrator)(t::Number,
                                      deriv::Type{Val{T}} = Val{0};
                                      idxs = nothing) where {T}
     out = similar(integrator.u)
-    integrator.flag = @checkflag IDAGetDky(integrator.mem, t, Cint(T), out)
+    integrator.flag = @checkflag IDAGetDky(integrator.mem, t, Cint(T), vec(out))
     return idxs === nothing ? out : out[idxs]
 end
 

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -208,7 +208,7 @@ function DiffEqBase.initialize_dae!(integrator::IDAIntegrator,
         else
             init_type = IDA_YA_YDP_INIT
             integrator.flag = IDASetId(integrator.mem,
-                                       integrator.sol.prob.differential_vars)
+                                       vec(integrator.sol.prob.differential_vars))
         end
         dt = integrator.dt == tstart ? tend : integrator.dt
         integrator.flag = IDACalcIC(integrator.mem, init_type, dt)

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -159,11 +159,11 @@ end
 end
 
 @inline function DiffEqBase.get_du(integrator::IDAIntegrator)
-    reshape(integrator.du, integrator.sizedu)
+    integrator.du
 end
 
 @inline function DiffEqBase.get_du!(out, integrator::IDAIntegrator)
-    out .= reshape(integrator.du, integrator.sizedu)
+    out .= integrator.du
 end
 
 function DiffEqBase.change_t_via_interpolation!(integrator::AbstractSundialsIntegrator, t)

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -102,7 +102,8 @@ function save_value!(save_array,
                      val,
                      ::Type{T},
                      save_idxs,
-                     make_copy::Type{Val{bool}} = Val{true}) where {T <: AbstractArray, bool}
+                     make_copy::Type{Val{bool}} = Val{true}) where {T <: AbstractArray, bool
+                                                                    }
     @assert val isa Array
     save = if save_idxs !== nothing
         val[save_idxs]

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -51,12 +51,12 @@ function DiffEqBase.savevalues!(integrator::AbstractSundialsIntegrator,
         curt = pop!(integrator.opts.saveat)
 
         tmp = integrator(curt)
-        save_value!(integrator.sol.u, tmp, uType, integrator.sizeu,
+        save_value!(integrator.sol.u, tmp, uType,
                     integrator.opts.save_idxs, Val{false})
         push!(integrator.sol.t, curt)
         if integrator.opts.dense
             tmp = integrator(curt, Val{1})
-            save_value!(integrator.sol.interp.du, tmp, uType, integrator.sizeu,
+            save_value!(integrator.sol.interp.du, tmp, uType,
                         integrator.opts.save_idxs, Val{false})
         end
     end
@@ -65,12 +65,12 @@ function DiffEqBase.savevalues!(integrator::AbstractSundialsIntegrator,
        (integrator.opts.save_everystep && (isempty(integrator.sol.t) ||
          (integrator.t !== integrator.sol.t[end])))
         saved = true
-        save_value!(integrator.sol.u, integrator.u, uType, integrator.sizeu,
+        save_value!(integrator.sol.u, integrator.u, uType,
                     integrator.opts.save_idxs)
         push!(integrator.sol.t, integrator.t)
         if integrator.opts.dense
             tmp = integrator(integrator.t, Val{1})
-            save_value!(integrator.sol.interp.du, tmp, uType, integrator.sizeu,
+            save_value!(integrator.sol.interp.du, tmp, uType,
                         integrator.opts.save_idxs)
         end
     end
@@ -81,15 +81,16 @@ end
 function save_value!(save_array,
                      val,
                      ::Type{T},
-                     sizeu, save_idxs,
+                     save_idxs,
                      make_copy::Type{Val{bool}} = Val{true}) where {T <: Number, bool}
     push!(save_array, first(val))
 end
 function save_value!(save_array,
                      val,
                      ::Type{T},
-                     sizeu, save_idxs,
+                     save_idxs,
                      make_copy::Type{Val{bool}} = Val{true}) where {T <: Vector, bool}
+    @assert val isa Array
     save = if save_idxs !== nothing
         val[save_idxs]
     else
@@ -100,20 +101,19 @@ end
 function save_value!(save_array,
                      val,
                      ::Type{T},
-                     sizeu, save_idxs,
-                     make_copy::Type{Val{bool}} = Val{true}) where {T <: AbstractArray, bool
-                                                                    }
+                     save_idxs,
+                     make_copy::Type{Val{bool}} = Val{true}) where {T <: AbstractArray, bool}
+    @assert val isa Array
     save = if save_idxs !== nothing
-        reshape(val, sizeu)[save_idxs]
+        val[save_idxs]
     else
         x = bool ? copy(val) : val
-        reshape(x, sizeu)
     end
     push!(save_array, save)
 end
 
 function handle_callback_modifiers!(integrator::CVODEIntegrator)
-    CVodeReInit(integrator.mem, integrator.t, integrator.u)
+    CVodeReInit(integrator.mem, integrator.t, integrator.u_nvec)
 end
 
 function handle_callback_modifiers!(integrator::ARKODEIntegrator)

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -108,7 +108,8 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
                            stop_at_next_tstop = false,
                            userdata = nothing,
                            alias_u0 = false,
-                           kwargs...) where {uType, tupType, isinplace, Method, LinearSolver}
+                           kwargs...) where {uType, tupType, isinplace, Method, LinearSolver
+                                             }
     tType = eltype(tupType)
 
     if verbose

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1336,7 +1336,6 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDAEProblem{uType, duType, tu
                                tout,
                                tdir,
                                sizeu,
-                               sizeu,
                                false,
                                tmp,
                                uprev,


### PR DESCRIPTION
This also makes the `u` and `du` fields into regular `Array` instead of a `NVector`. This yak had a lot of hair.