### PR TITLE
Correct OrdinaryDiffEq DAE init integration

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1223,26 +1223,9 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDAEProblem{uType, duType, tu
         jac = nothing
     end
 
-    tout = [tspan[1]]
-    if save_start
-        if save_idxs === nothing
-            ures = Vector{uType}()
-            dures = Vector{uType}()
-            save_value!(ures, u0, uType, save_idxs)
-            if dense
-                save_value!(dures, du0, uType, save_idxs)
-            end
-        else
-            ures = [u0[save_idxs]]
-            if dense
-                dures = [du0[save_idxs]]
-            end
-        end
-    else
-        ures = Vector{uType}()
-        dures = Vector{uType}()
-    end
-
+    tout = Float64[]
+    ures = Vector{uType}()
+    dures = Vector{uType}()
     tmp = isnothing(callbacks_internal) ? u0 : similar(u0)
     uprev = isnothing(callbacks_internal) ? u0 : similar(u0)
     retcode = flag >= 0 ? ReturnCode.Default : ReturnCode.InitialFailure
@@ -1312,6 +1295,13 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDAEProblem{uType, duType, tu
 
     DiffEqBase.initialize_dae!(integrator, initializealg)
     integrator.u_modified && IDAReinit!(integrator)
+
+    if save_start
+        push!(tout, integrator.t)
+        save_value!(ures, integrator.u, uType, save_idxs)
+        save_value!(dures, integrator.u, uType, save_idxs)
+    end
+
     initialize_callbacks!(integrator)
     integrator
 end # function solve

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1311,6 +1311,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDAEProblem{uType, duType, tu
                                initializealg)
 
     DiffEqBase.initialize_dae!(integrator, initializealg)
+    integrator.u_modified && IDAReinit!(integrator)
     initialize_callbacks!(integrator)
     integrator
 end # function solve

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -96,10 +96,10 @@ init(dae_prob, IDA(), initializealg = NoInit()).u == [0.0]
 
 # test that initializers which modify states actually modify the states
 struct DumbInit <: DiffEqBase.DAEInitializationAlgorithm end
-function DiffEqBase.initialize_dae!(integrator::IDAIntegrator, initializealg::DumbInit)
+function DiffEqBase.initialize_dae!(integrator::Sundials.IDAIntegrator, initializealg::DumbInit)
     integrator.u .= 1
     integrator.u_modified = true
-    DiffEqBase.initialize_dae!(integrator, IDADefaultInit())
+    DiffEqBase.initialize_dae!(integrator, Sundials.IDADefaultInit())
 end
 f(du, u, p, t) = du - u # u(t) = exp(t)
 prob = DAEProblem(f, zeros(1), zeros(1), (0, 1), differential_vars = trues(1))


### PR DESCRIPTION
This corrects two issues with the DAE init integration added in #401:

1. It makes sure that shadow copy of the state in the integrator struct is reflected back into IDA (with https://github.com/SciML/OrdinaryDiffEq.jl/pull/1969). This needs to handle two distinct cases:
  a. Where a DiffEq DAE initialization algorithm is used directly (handled by checking u modified after the call to DAE init)
  b. Where a DiffEq DAE init is chained into the IDA default init (handled by the check at the top of IDADefaultInit.
It also needs to make sure to reflect the values that IDADefaultInit came up with back into integrator.u to make sure that it can be read from there for anybody who might wish to inspect it.

2. The order of save_start and initialize_dae! was reversed, causing the first entry of the solution to always be `prob.u0` rather than the result of DAE initialization.