### PR TITLE
Stop interpolating to get du for IDA.

### DIFF
--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -78,37 +78,14 @@ function DiffEqBase.savevalues!(integrator::AbstractSundialsIntegrator,
     return saved, savedexactly
 end
 
-function save_value!(save_array,
-                     val,
-                     ::Type{T},
-                     save_idxs,
-                     make_copy::Type{Val{bool}} = Val{true}) where {T <: Number, bool}
+function save_value!(save_array, val, ::Type{<:Number}, save_idxs, make_copy::Bool = true)
     push!(save_array, first(val))
 end
-function save_value!(save_array,
-                     val,
-                     ::Type{T},
-                     save_idxs,
-                     make_copy::Type{Val{bool}} = Val{true}) where {T <: Vector, bool}
-    @assert val isa Array
+function save_value!(save_array, val, ::Type{<:AbstractArray}, save_idxs, make_copy::Bool = true)
     save = if save_idxs !== nothing
         val[save_idxs]
     else
-        bool ? copy(val) : val
-    end
-    push!(save_array, save)
-end
-function save_value!(save_array,
-                     val,
-                     ::Type{T},
-                     save_idxs,
-                     make_copy::Type{Val{bool}} = Val{true}) where {T <: AbstractArray, bool
-                                                                    }
-    @assert val isa Array
-    save = if save_idxs !== nothing
-        val[save_idxs]
-    else
-        x = bool ? copy(val) : val
+        make_copy ? copy(val) : val
     end
     push!(save_array, save)
 end

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -69,7 +69,7 @@ function DiffEqBase.savevalues!(integrator::AbstractSundialsIntegrator,
                     integrator.opts.save_idxs)
         push!(integrator.sol.t, integrator.t)
         if integrator.opts.dense
-            tmp = integrator(integrator.t, Val{1})
+            tmp = DiffEqBase.get_du(integrator)
             save_value!(integrator.sol.interp.du, tmp, uType,
                         integrator.opts.save_idxs)
         end
@@ -151,11 +151,11 @@ function DiffEqBase.terminate!(integrator::AbstractSundialsIntegrator,
     integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
 end
 
-@inline function DiffEqBase.get_du(integrator::CVODEIntegrator)
+@inline function DiffEqBase.get_du(integrator::AbstractSundialsIntegrator)
     integrator(integrator.t, Val{1})
 end
 
-@inline function DiffEqBase.get_du!(out, integrator::CVODEIntegrator)
+@inline function DiffEqBase.get_du!(out, integrator::AbstractSundialsIntegrator)
     integrator(out, integrator.t, Val{1})
 end
 

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -52,12 +52,12 @@ function DiffEqBase.savevalues!(integrator::AbstractSundialsIntegrator,
 
         tmp = integrator(curt)
         save_value!(integrator.sol.u, tmp, uType,
-                    integrator.opts.save_idxs, Val{false})
+                    integrator.opts.save_idxs, false)
         push!(integrator.sol.t, curt)
         if integrator.opts.dense
             tmp = integrator(curt, Val{1})
             save_value!(integrator.sol.interp.du, tmp, uType,
-                        integrator.opts.save_idxs, Val{false})
+                        integrator.opts.save_idxs, false)
         end
     end
 

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1432,7 +1432,6 @@ function DiffEqBase.solve!(integrator::AbstractSundialsIntegrator; early_free = 
                     integrator.opts.save_idxs)
         push!(integrator.sol.t, integrator.t)
         if integrator.opts.dense
-            integrator(integrator.u, integrator.t, Val{1})
             save_value!(integrator.sol.interp.du, integrator.u, uType,
                         integrator.opts.save_idxs)
         end

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -1,0 +1,25 @@
+using Sundials, Test, DiffEqBase
+using ForwardDiff
+import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
+
+function regression_test(alg, tol_ode_linear, tol_ode_2Dlinear)
+    sol = solve(prob_ode_linear, alg, dense = true, abstol=1e-8, reltol=1e-8)
+    @inferred sol(.5)
+    u0 = sol[1]
+    p = sol.prob.p
+    for t in 0.0:1/16:1.0
+        @test isapprox(u0 * exp(p*t), sol(t), rtol=tol_ode_linear)
+    end
+
+    sol = solve(prob_ode_2Dlinear, alg, dt = 1 / 2^(2), dense = true)
+    sol2 = solve(prob_ode_2Dlinear, alg, dense = true, abstol=1e-8, reltol=1e-8)
+    u0 = sol[1]
+    p = sol.prob.p
+    for t in 0.0:1/16:1.0
+        @test isapprox(u0 .* exp(p*t), sol(t), rtol=tol_ode_2Dlinear)
+    end
+end
+
+regression_test(ARKODE(), 1e-5, 1e-4)
+regression_test(CVODE_BDF(), 1e-6, 1e-2)
+regression_test(CVODE_Adams(), 1e-6, 1e-3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,3 +41,5 @@ end
     @testset "Mass Matrix" begin include("common_interface/mass_matrix.jl") end
     @testset "Preconditioners" begin include("common_interface/precs.jl") end
 end
+
+@testset "Interpolation" begin include("interpolation.jl") end


### PR DESCRIPTION
This fixes https://github.com/SciML/Sundials.jl/issues/292. It turns out we were asking for interpolated derivatives for essentially no reason (and doing so caused problems whenever you hit callbacks that re-init the problem). As a nice side-benefit, this removes the 200 warnings from the test-suite.