### PR TITLE
prevent solvers from getting stuck at the same timepoint without giving an error

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1400,6 +1400,9 @@ function DiffEqBase.solve!(integrator::AbstractSundialsIntegrator; early_free = 
             integrator.userfun.p = integrator.p
             solver_step(integrator, tstop)
             integrator.t = first(integrator.tout)
+            if integrator.t == integrator.tprev
+                integrator.flag = -3
+            end
             integrator.flag < 0 && break
             handle_callbacks!(integrator) # this also updates the interpolation
             integrator.flag < 0 && break

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -112,3 +112,8 @@ sol = solve(prob, IDA(), initializealg = DumbInit())
 isapprox(only(sol.u[begin]), 1, rtol = 1e-3)
 # test that solve produced the right answer.
 isapprox(only(sol.u[end]), exp(1), rtol = 1e-3)
+
+f_noconverge(out, du, u, p, t) = out .= [du[1]+u[1]/(t-1)]
+prob= DAEProblem(f, [1.], [1.], (0,2); differential_vars=[true])
+sol = solve(prob, IDA())
+@test !(sol.retcode in (ReturnCode.Success, ReturnCode.MaxIters)


### PR DESCRIPTION
This was found while trying to find a MWE for https://github.com/SciML/SciMLBase.jl/issues/458