### PR TITLE
fix `IDA` with scalar `save_idxs`

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -1224,8 +1224,13 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDAEProblem{uType, duType, tu
     end
 
     tout = Float64[first(tspan)]
-    ures = Vector{uType}()
-    dures = Vector{uType}()
+    if save_idxs isa Integer
+        ures = Vector{eltype(uType)}()
+        dures = Vector{eltype(uType)}()
+    else
+        ures = Vector{uType}()
+        dures = Vector{uType}()
+    end
     tmp = isnothing(callbacks_internal) ? u0 : similar(u0)
     uprev = isnothing(callbacks_internal) ? u0 : similar(u0)
     retcode = flag >= 0 ? ReturnCode.Default : ReturnCode.InitialFailure

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -59,8 +59,9 @@ sol = solve(prob, IDA(); saveat = saveat, save_everystep = true)
 @test intersect(sol.t, saveat) == saveat
 @info "IDA with tstops"
 sol = solve(prob, IDA(); tstops = [0.9])
-
 @test 0.9 ∈ sol.t
+
+@test solve(prob, IDA(); save_idxs=1).u isa Vector{Float64}
 
 prob = deepcopy(prob_dae_resrob)
 prob2 = DAEProblem(prob.f, prob.du0, prob.u0, (1.0, 0.0))


### PR DESCRIPTION
when `save_idxs` is an `Integer` we should only save a `Vector{Float64}` rather than a `Vector{Vector{Float64}}`. Fixes https://github.com/SciML/Sundials.jl/issues/418