### PR TITLE
Mark `SubArray`s as invalid outputs for `IDAIntegrator(out, t)`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,6 @@ jobs:
           - Core
         version:
           - '1'
-          - '1.6'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ PrecompileTools = "1"
 Reexport = "0.2, 1.0"
 SciMLBase = "1.92, 2"
 Sundials_jll = "5.2"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"

--- a/src/common_interface/integrator_types.jl
+++ b/src/common_interface/integrator_types.jl
@@ -200,6 +200,13 @@ function (integrator::IDAIntegrator)(out,
     integrator.flag = @checkflag IDAGetDky(integrator.mem, t, Cint(T), vec(out))
     return idxs === nothing ? out : @view out[idxs]
 end
+function (integrator::IDAIntegrator)(out::SubArray,
+    t::Number,
+    deriv::Type{Val{T}} = Val{0};
+    idxs = nothing) where {T}
+    throw(ArgumentError("Views are not supported with IDA!"))
+end
+
 
 ###  Error check (retcode)
 

--- a/test/common_interface/callbacks.jl
+++ b/test/common_interface/callbacks.jl
@@ -81,3 +81,10 @@ cb = ContinuousCallback(bvcond, bvaffect!)
 prob = DAEProblem(fbv, du₀, u₀, tspan, p, differential_vars = differential_vars)
 sol = solve(prob, IDA(), callback = cb, tstops = [50.0], abstol = 1e-12, reltol = 1e-12)
 @test sol.t[end] ≈ 100.0
+
+# Test that SubArrays are not allowed as outputs to the integrator
+u_out = similar(u₀)
+cb = DiscreteCallback(Returns(true), integ -> integ(@view(u_out), integ.t)
+prob = DAEProblem(fbv, du₀, u₀, tspan, p, differential_vars = differential_vars)
+@test_throws ArgumentError solve(prob, IDA(), callback = cb)
+

--- a/test/common_interface/callbacks.jl
+++ b/test/common_interface/callbacks.jl
@@ -84,7 +84,7 @@ sol = solve(prob, IDA(), callback = cb, tstops = [50.0], abstol = 1e-12, reltol 
 
 # Test that SubArrays are not allowed as outputs to the integrator
 u_out = similar(u₀)
-cb = DiscreteCallback(Returns(true), integ -> integ(@view(u_out), integ.t)
+cb = DiscreteCallback(Returns(true), integ -> integ(@view(u_out), integ.t))
 prob = DAEProblem(fbv, du₀, u₀, tspan, p, differential_vars = differential_vars)
 @test_throws ArgumentError solve(prob, IDA(), callback = cb)
 

--- a/test/common_interface/callbacks.jl
+++ b/test/common_interface/callbacks.jl
@@ -84,7 +84,7 @@ sol = solve(prob, IDA(), callback = cb, tstops = [50.0], abstol = 1e-12, reltol 
 
 # Test that SubArrays are not allowed as outputs to the integrator
 u_out = similar(u₀)
-cb = DiscreteCallback(Returns(true), integ -> integ(@view(u_out), integ.t))
+cb = DiscreteCallback(Returns(true), integ -> integ(@view(u_out[2:2]), integ.t))
 prob = DAEProblem(fbv, du₀, u₀, tspan, p, differential_vars = differential_vars)
 @test_throws ArgumentError solve(prob, IDA(), callback = cb)
 


### PR DESCRIPTION
Let's imagine we have a matrix that we are filling out, column by column with `integrator(t)`, but we realize we want to use the non-allocating version. We try to use `integrator(out[:, idx], t)`, and then realize that of course we need to make that a view because otherwise slicing just creates a copy. Imagine our surprise when the view doesn't work either.  Indeed:

```julia
julia> out = zeros(3)
       outv = @view(out[:])
       nv = convert(Sundials.NVector, outv)
       nv[1] = 1.0
       out
3-element Vector{Float64}:
 0.0
 0.0
 0.0
```

The issue, as it turns out, is due to the `convert(NVector, x)` overload automatically making a copy of non-plain `Vector` types.  I understand the reasoning behind this, as the backing memory store needs to be contiguous memory.  It may be possible to write a correct dispatch for `SubArray`s that are contiguous vectors, but I'm not sure how to do that, and so have opted instead to just make this an error rather than silently return untouched memory.