### PR TITLE
use `vcat` rather than `append!` to combine `d_discontinuities` and `tstops`

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -147,7 +147,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
 
     progress && Logging.@logmsg(Logging.LogLevel(-1), progress_name, _id=progress_id, progress=0)
 
-    append!(tstops, d_discontinuities)
+    tstops = vcat(tstops, d_discontinuities)
     callbacks_internal = DiffEqBase.CallbackSet(callback)
 
     max_len_cb = DiffEqBase.max_vector_callback_length(callbacks_internal)
@@ -515,7 +515,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
 
     progress && Logging.@logmsg(Logging.LogLevel(-1), progress_name, _id=progress_id, progress=0)
 
-    append!(tstops, d_discontinuities)
+    tstops = vcat(tstops, d_discontinuities)
     callbacks_internal = DiffEqBase.CallbackSet(callback)
 
     max_len_cb = DiffEqBase.max_vector_callback_length(callbacks_internal)
@@ -1026,7 +1026,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDAEProblem{uType, duType, tu
 
     progress && Logging.@logmsg(Logging.LogLevel(-1), progress_name, _id=progress_id, progress=0)
 
-    append!(tstops, d_discontinuities)
+    tstops = vcat(tstops, d_discontinuities)
     callbacks_internal = DiffEqBase.CallbackSet(callback)
 
     max_len_cb = DiffEqBase.max_vector_callback_length(callbacks_internal)

--- a/test/common_interface/cvode.jl
+++ b/test/common_interface/cvode.jl
@@ -45,9 +45,10 @@ sol = solve(prob, CVODE_Adams(); saveat = saveat, save_everystep = false)
 
 @test sol.t == saveat
 
-sol = solve(prob, CVODE_Adams(); tstops = [0.9])
-
-@test 0.9 ∈ sol.t
+for tstops in [0.9, [0.9]]
+    sol = solve(prob,  CVODE_Adams(); tstops)
+    @test 0.9 ∈ sol.t
+end
 
 sol = solve(prob, CVODE_Adams())
 sol_idxs = solve(prob, CVODE_Adams(); save_idxs = [1], timeseries_errors = false)

--- a/test/common_interface/ida.jl
+++ b/test/common_interface/ida.jl
@@ -58,8 +58,10 @@ sol = solve(prob, IDA(); saveat = saveat, save_everystep = true)
 @test sol.t != saveat
 @test intersect(sol.t, saveat) == saveat
 @info "IDA with tstops"
-sol = solve(prob, IDA(); tstops = [0.9])
-@test 0.9 ∈ sol.t
+for tstops in [0.9, [0.9]]
+    sol = solve(prob, IDA(); tstops)
+    @test 0.9 ∈ sol.t
+end
 
 sol = solve(prob, IDA(); d_discontinuities = [0.9])
 @test 0.9 ∈ sol.t


### PR DESCRIPTION
this version works when `tstops` is a scalar.

## Checklist

- [ ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
