### PR TITLE
Memory-safety and allocations fixes for Handle{T}

### DIFF
--- a/test/handle_tests.jl
+++ b/test/handle_tests.jl
@@ -13,7 +13,7 @@ empty!(h1)
 
 empty!(h1) # Make sure this does not throw
 
-h = Sundials.Handle(h1.ptr_ref[]) # Check construction with null pointers
+h = Sundials.Handle(h1.ptr) # Check construction with null pointers
 @test isempty(h)
 
 neq = 3


### PR DESCRIPTION
Addresses https://github.com/SciML/Sundials.jl/issues/435 and also fixes a potential problem with memory safety:

1) Allocations in convert(Ptr{T}, Handle{T})
   Fix is as suggested in https://github.com/SciML/Sundials.jl/issues/435
   (Handle is now a mutable struct with a ptr field)

2) Memory safety robustness fix
   Remove convert and use paired Base.cconvert / Base.unsafe_convert to get the ptr field from
   a Handle object h, so that the h is preserved from GC across the ccall
   This fix is analogous to that for the NVector wrapper in PR https://github.com/SciML/Sundials.jl/pull/380
   (NB: there is no actual problem at least when Sundials is used with the SciML interface,
   as the Handle{CVODEMem} and similar objects are held by a persistent solver data structure, but this
   change should reduce the risk of something going wrong in the future, or for eg test harnesses that don't use
   the SciML interface)

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
