### PR TITLE
fix test passing integer to differential_vars

### DIFF
--- a/test/common_interface/errors.jl
+++ b/test/common_interface/errors.jl
@@ -11,7 +11,7 @@ sol = solve(prob, CVODE_BDF(); verbose = false)
 f_error2(du, u, p, t) = du .= u ./ t .- 1
 u0 = [1.0];
 du0 = [1.0];
-prob = DAEProblem(f_error2, u0, du0, (0.0, 1.0); differential_vars = [1])
+prob = DAEProblem(f_error2, u0, du0, (0.0, 1.0); differential_vars = [true])
 sol = solve(prob, IDA())
 sol = solve(prob, IDA(); verbose = false)
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I am a little surprised this worked before, but I guess it is because `ccall` converts or something like that.

The docs say that
> `differential_vars`: A logical array...

https://github.com/SciML/SciMLBase.jl/blob/7611e7614312dab369f76ab5dc7221a7c417b5e4/src/problems/dae_problems.jl#L50

The fix is trivial, and makes this consistent with the other Sundials examples.