### PR TITLE
Review and document deprecation warnings status

### DIFF
--- a/DEPRECATION_REVIEW.md
+++ b/DEPRECATION_REVIEW.md
@@ -1,0 +1,28 @@
+# Deprecation Warning Review
+
+## Summary
+This document summarizes the review of deprecation warnings in the Sundials.jl package as of January 2025.
+
+## Findings
+
+### Method Definition Warnings (Not Deprecations)
+During testing, the following warnings appear:
+- `WARNING: Method definition f(Any, Any, Any, Any) overwritten` in various test files
+
+These are **not deprecation warnings** but rather warnings about function redefinition during test execution. This is a common pattern in test suites where similar function names are used across different test files.
+
+### Files with Method Redefinitions:
+- `test/cvode_Roberts_dns.jl`: function `f`
+- `test/arkstep_Roberts_dns.jl`: function `f` 
+- `test/erkstep_nonlin.jl`: function `f`
+- `test/kinsol_banded.jl`: functions `f_iip`, `f_oop`
+- `test/kinsol_nonlinear_solve.jl`: functions `f_iip`, `f_oop`
+- `test/common_interface/ida.jl`: function `f!`
+- `test/common_interface/jacobians.jl`: functions `testjac`, `testjac_jac`
+
+## Conclusion
+No actual Julia language deprecation warnings were found in Sundials.jl. The package is up-to-date with current Julia practices. The method definition warnings are benign and common in test suites.
+
+## CI Status
+✅ Tests pass successfully
+✅ No actual deprecation warnings present


### PR DESCRIPTION
## Summary
Reviewed CI logs and test output for deprecation warnings in Sundials.jl.

## Findings
- No actual Julia language deprecation warnings found
- Method definition warnings in tests are benign function redefinitions, not deprecations
- Package is up-to-date with current Julia practices

## Changes
- Added `DEPRECATION_REVIEW.md` documenting investigation results
- Confirmed all tests pass successfully

## Test plan
- [x] Ran full test suite locally
- [x] Confirmed no actual deprecation warnings present
- [x] Verified CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)