### PR TITLE
Fix ARKODE mass matrix test comparison

### DIFF
--- a/test/common_interface/mass_matrix.jl
+++ b/test/common_interface/mass_matrix.jl
@@ -36,6 +36,8 @@ prob, prob2 = make_mm_probs(mm_A, Val{true})
 sol = solve(prob, ARKODE(); abstol = 1e-8, reltol = 1e-8)
 sol2 = solve(prob2, ARKODE(); abstol = 1e-8, reltol = 1e-8)
 
-# TODO: This test is failing in SUNDIALS 7.4 - mass matrix functionality may be broken
-# Expected: norm(sol - sol2) ≈ 0, Actual: norm(sol - sol2) ≈ 0.0295
-@test_broken norm(sol .- sol2)≈0 atol=1e-7
+# Compare solutions at common time points since they may have different internal timesteps
+# The adaptive timestepping may choose different points internally
+t_common = range(0.0, 1.0, length=100)
+max_diff = maximum(norm(sol(t) - sol2(t)) for t in t_common)
+@test max_diff < 1e-7


### PR DESCRIPTION
## Summary
- Fixed incorrect test comparison in mass matrix test that was causing false failures
- The test now properly compares solutions at common time points instead of at adaptive timesteps

## Problem
The mass matrix test was marked as `@test_broken` because it appeared that ARKODE's mass matrix functionality was producing incorrect results. The test was comparing two mathematically equivalent problems:
1. With mass matrix: `M * du/dt = A*u + t*b` where `M^(-1)*A = I` and `M^(-1)*b = [1,1,1]`
2. Without mass matrix: `du/dt = u + t*[1,1,1]`

The test was failing with `norm(sol .- sol2) ≈ 0.0295` instead of the expected ~0.

## Root Cause
The issue was not with SUNDIALS or the mass matrix implementation, but with how the solutions were being compared. The test used `norm(sol .- sol2)` which compares solutions at their internal adaptive timesteps. Since the two solvers may choose different timesteps during adaptive integration, this comparison was invalid.

## Solution
Changed the test to compare solutions at 100 common time points using interpolation. At these common points, the maximum difference is < 1e-7, confirming that the mass matrix functionality works correctly.

## Test Results
The mass matrix test now passes successfully, confirming that ARKODE's mass matrix functionality is working as expected.

🤖 Generated with [Claude Code](https://claude.ai/code)