### PR TITLE
Update CI workflow to include Julia version and architecture and actually use mac aarch64

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} ${{ matrix.arch }}
+  
     strategy:
       fail-fast: false
       matrix:
@@ -24,8 +25,13 @@ jobs:
           - "pre"
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
+        arch:
+          - x64
+        include:
+          - os: macOS-latest
+            arch: aarch64
+            version: '1'          
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
