### PR TITLE
Update Clang generator for Sundials

### DIFF
--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -4,4 +4,4 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 Sundials_jll = "fb77eaff-e24c-56d4-86b1-d163f2edb164"
 
 [compat]
-Clang = "0.14.0"
+Clang = "0.19"

--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -1,5 +1,5 @@
 using Clang.Generators
-using Sundials_jll
+using Sundials_jll, SuiteSparse32_jll
 using MLStyle
 using Pkg
 
@@ -234,17 +234,15 @@ cd(@__DIR__)
 
 include_dir = joinpath(Sundials_jll.artifact_dir, "include") |> normpath
 
-artifact_toml = joinpath(dirname(pathof(Sundials_jll.SuiteSparse_jll)), "..",
-    "StdlibArtifacts.toml")
-suitespase_dir = Pkg.Artifacts.ensure_artifact_installed("SuiteSparse", artifact_toml)
-suitespase_include_sir = joinpath(suitespase_dir, "include")
+suitesparse_dir = SuiteSparse32_jll.artifact_dir
+suitesparse_include_dir = joinpath(suitesparse_dir, "include")
 
 # wrapper generator options
 options = load_options(joinpath(@__DIR__, "generate.toml"))
 
 # add compiler flags, e.g. "-DXXXXXXXXX"
 args = get_default_args()
-push!(args, "-I$include_dir", "-isystem$suitespase_include_sir")
+push!(args, "-I$include_dir", "-isystem$suitesparse_include_dir")
 
 library_names = Dict(raw"sundials[\\/].+" => "libsundials_sundials",
     raw"sunnonlinsol[\\/].+" => "libsundials_sunnonlinsol",
@@ -272,7 +270,7 @@ ctx = create_context(headers, args, options)
 
 # run generator
 build!(ctx, BUILDSTAGE_NO_PRINTING)
-for n in ctx.dag.nodes
-    copy!(n.exprs, reduce(vcat, rewrite.(n.exprs); init = []))
-end
+#for n in ctx.dag.nodes
+#    copy!(n.exprs, reduce(vcat, rewrite.(n.exprs); init = []))
+#end
 build!(ctx, BUILDSTAGE_PRINTING_ONLY)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

The old clang generator scripts need updating to use Clang 0.19 and should also itself be run in the CI. 

The current wrappers are for sundials v5 that have been updated for v7 by Claude, and it would be great to have a clean upgrade of the wrappers.