### PR TITLE
Fix x86 (32-bit) compatibility issues with Int64 conversions

### DIFF
--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -256,7 +256,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
     if Method == :Newton # Only use a linear solver if it's a Newton-based method
         if LinearSolver in (:Dense, :LapackDense)
             nojacobian = false
-            A = SUNDenseMatrix(length(uvec), length(uvec), ctx)
+            A = SUNDenseMatrix(Int64(length(uvec)), Int64(length(uvec)), ctx)
             _A = MatrixHandle(A, DenseMatrix())
             if LinearSolver === :Dense
                 LS = SUNLinSol_Dense(utmp, A, ctx)
@@ -267,7 +267,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
             end
         elseif LinearSolver in (:Band, :LapackBand)
             nojacobian = false
-            A = SUNBandMatrix(length(uvec), alg.jac_upper, alg.jac_lower, ctx)
+            A = SUNBandMatrix(Int64(length(uvec)), Int64(alg.jac_upper), Int64(alg.jac_lower), ctx)
             _A = MatrixHandle(A, BandMatrix())
             if LinearSolver === :Band
                 LS = SUNLinSol_Band(utmp, A, ctx)
@@ -304,7 +304,8 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
         elseif LinearSolver == :KLU
             nojacobian = false
             nnz = length(SparseArrays.nonzeros(prob.f.jac_prototype))
-            A = SUNSparseMatrix(length(uvec), length(uvec), nnz, CSC_MAT, ctx)
+            A = SUNSparseMatrix(
+                Int64(length(uvec)), Int64(length(uvec)), Int64(nnz), CSC_MAT, ctx)
             LS = SUNLinSol_KLU(utmp, A, ctx)
             _A = MatrixHandle(A, SparseMatrix())
             _LS = LinSolHandle(LS, KLU())
@@ -731,7 +732,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
     if Method == :Newton && alg.stiffness !== Explicit() # Only use a linear solver if it's a Newton-based method
         if LinearSolver in (:Dense, :LapackDense)
             nojacobian = false
-            A = SUNDenseMatrix(length(uvec), length(uvec), ctx)
+            A = SUNDenseMatrix(Int64(length(uvec)), Int64(length(uvec)), ctx)
             _A = MatrixHandle(A, DenseMatrix())
             if LinearSolver === :Dense
                 LS = SUNLinSol_Dense(utmp, A, ctx)
@@ -742,7 +743,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
             end
         elseif LinearSolver in (:Band, :LapackBand)
             nojacobian = false
-            A = SUNBandMatrix(length(uvec), alg.jac_upper, alg.jac_lower, ctx)
+            A = SUNBandMatrix(Int64(length(uvec)), Int64(alg.jac_upper), Int64(alg.jac_lower), ctx)
             _A = MatrixHandle(A, BandMatrix())
             if LinearSolver === :Band
                 LS = SUNLinSol_Band(utmp, A, ctx)
@@ -773,7 +774,8 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
             _LS = LinSolHandle(LS, PTFQMR())
         elseif LinearSolver == :KLU
             nnz = length(SparseArrays.nonzeros(prob.f.jac_prototype))
-            A = SUNSparseMatrix(length(uvec), length(uvec), nnz, CSC_MAT, ctx)
+            A = SUNSparseMatrix(
+                Int64(length(uvec)), Int64(length(uvec)), Int64(nnz), CSC_MAT, ctx)
             LS = SUNLinSol_KLU(utmp, A, ctx)
             _A = MatrixHandle(A, SparseMatrix())
             _LS = LinSolHandle(LS, KLU())
@@ -804,7 +806,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
     if prob.f.mass_matrix != LinearAlgebra.I && alg.stiffness !== Explicit()
         if MassLinearSolver in (:Dense, :LapackDense)
             nojacobian = false
-            M = SUNDenseMatrix(length(uvec), length(uvec), ctx)
+            M = SUNDenseMatrix(Int64(length(uvec)), Int64(length(uvec)), ctx)
             _M = MatrixHandle(M, DenseMatrix())
             if MassLinearSolver === :Dense
                 MLS = SUNLinSol_Dense(utmp, M, ctx)
@@ -815,7 +817,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
             end
         elseif MassLinearSolver in (:Band, :LapackBand)
             nojacobian = false
-            M = SUNBandMatrix(length(uvec), alg.jac_upper, alg.jac_lower, ctx)
+            M = SUNBandMatrix(Int64(length(uvec)), Int64(alg.jac_upper), Int64(alg.jac_lower), ctx)
             _M = MatrixHandle(M, BandMatrix())
             if MassLinearSolver === :Band
                 MLS = SUNLinSol_Band(utmp, M, ctx)
@@ -846,7 +848,8 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractODEProblem{uType, tupType, i
             _MLS = LinSolHandle(MLS, PTFQMR())
         elseif MassLinearSolver == :KLU
             nnz = length(SparseArrays.nonzeros(prob.f.mass_matrix))
-            M = SUNSparseMatrix(length(uvec), length(uvec), nnz, CSC_MAT, ctx)
+            M = SUNSparseMatrix(
+                Int64(length(uvec)), Int64(length(uvec)), Int64(nnz), CSC_MAT, ctx)
             MLS = SUNLinSol_KLU(utmp, M, ctx)
             _M = MatrixHandle(M, SparseMatrix())
             _MLS = LinSolHandle(MLS, KLU())
@@ -1176,7 +1179,7 @@ function DiffEqBase.__init(
     prec_side = isnothing(alg.prec) ? 0 : 1  # IDA only supports left preconditioning (prec_side = 1)
     if LinearSolver in (:Dense, :LapackDense)
         nojacobian = false
-        A = SUNDenseMatrix(length(u0), length(u0), ctx)
+        A = SUNDenseMatrix(Int64(length(u0)), Int64(length(u0)), ctx)
         _A = MatrixHandle(A, DenseMatrix())
         if LinearSolver === :Dense
             LS = SUNLinSol_Dense(utmp, A, ctx)
@@ -1187,7 +1190,7 @@ function DiffEqBase.__init(
         end
     elseif LinearSolver in (:Band, :LapackBand)
         nojacobian = false
-        A = SUNBandMatrix(length(u0), alg.jac_upper, alg.jac_lower, ctx)
+        A = SUNBandMatrix(Int64(length(u0)), Int64(alg.jac_upper), Int64(alg.jac_lower), ctx)
         _A = MatrixHandle(A, BandMatrix())
         if LinearSolver === :Band
             LS = SUNLinSol_Band(utmp, A, ctx)
@@ -1218,7 +1221,8 @@ function DiffEqBase.__init(
         _LS = LinSolHandle(LS, PTFQMR())
     elseif LinearSolver == :KLU
         nnz = length(SparseArrays.nonzeros(prob.f.jac_prototype))
-        A = SUNSparseMatrix(length(u0), length(u0), nnz, Sundials.CSC_MAT, ctx)
+        A = SUNSparseMatrix(
+            Int64(length(u0)), Int64(length(u0)), Int64(nnz), Sundials.CSC_MAT, ctx)
         LS = SUNLinSol_KLU(utmp, A, ctx)
         _A = MatrixHandle(A, SparseMatrix())
         _LS = LinSolHandle(LS, KLU())

--- a/src/nvector_wrapper.jl
+++ b/src/nvector_wrapper.jl
@@ -17,7 +17,7 @@ mutable struct NVector <: DenseVector{realtype}
     function NVector(v::Vector{realtype}, ctx::SUNContext)
         # note that N_VMake_Serial() creates N_Vector doesn't own the data,
         # so calling N_VDestroy_Serial() would not deallocate v
-        nv = new(N_VMake_Serial(length(v), v, ctx), v, ctx)
+        nv = new(N_VMake_Serial(Int64(length(v)), v, ctx), v, ctx)
         finalizer(release_handle, nv)
         return nv
     end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -79,16 +79,16 @@ function ___kinsol(f,
     y0_nvec = NVector(y0, ctx)
     flag = @checkflag KINInit(kmem, getcfun(userfun), y0_nvec) true
     if linear_solver == :Dense
-        A = Sundials.SUNDenseMatrix(length(y0), length(y0), ctx)
+        A = Sundials.SUNDenseMatrix(Int64(length(y0)), Int64(length(y0)), ctx)
         LS = Sundials.SUNLinSol_Dense(y0_nvec, A, ctx)
     elseif linear_solver == :LapackDense
-        A = Sundials.SUNDenseMatrix(length(y0), length(y0), ctx)
+        A = Sundials.SUNDenseMatrix(Int64(length(y0)), Int64(length(y0)), ctx)
         LS = Sundials.SUNLinSol_LapackDense(y0_nvec, A, ctx)
     elseif linear_solver == :Band
-        A = Sundials.SUNBandMatrix(length(y0), jac_upper, jac_lower, ctx)
+        A = Sundials.SUNBandMatrix(Int64(length(y0)), Int64(jac_upper), Int64(jac_lower), ctx)
         LS = Sundials.SUNLinSol_Band(y0_nvec, A, ctx)
     elseif linear_solver == :LapackBand
-        A = Sundials.SUNBandMatrix(length(y0), jac_upper, jac_lower, ctx)
+        A = Sundials.SUNBandMatrix(Int64(length(y0)), Int64(jac_upper), Int64(jac_lower), ctx)
         LS = Sundials.SUNLinSol_LapackBand(y0_nvec, A, ctx)
     elseif linear_solver == :GMRES
         A = C_NULL
@@ -107,7 +107,8 @@ function ___kinsol(f,
         LS = Sundials.SUNLinSol_SPTFQMR(y0_nvec, Cint(prec_side), Cint(krylov_dim), ctx)
     elseif linear_solver == :KLU
         nnz = length(SparseArrays.nonzeros(jac_prototype))
-        A = Sundials.SUNSparseMatrix(length(y0), length(y0), nnz, CSC_MAT, ctx)
+        A = Sundials.SUNSparseMatrix(
+            Int64(length(y0)), Int64(length(y0)), Int64(nnz), CSC_MAT, ctx)
         LS = SUNLinSol_KLU(y0_nvec, A, ctx)
     else
         error("Unknown linear solver")
@@ -214,7 +215,7 @@ function cvode!(f::Function,
 
     flag = @checkflag CVodeSetUserData(mem, userfun) true
     flag = @checkflag CVodeSStolerances(mem, reltol, abstol) true
-    A = Sundials.SUNDenseMatrix(length(y0), length(y0), ctx)
+    A = Sundials.SUNDenseMatrix(Int64(length(y0)), Int64(length(y0)), ctx)
     LS = Sundials.SUNLinSol_Dense(y0nv, A, ctx)
     flag = Sundials.@checkflag Sundials.CVDlsSetLinearSolver(mem, LS, A) true
 
@@ -301,7 +302,7 @@ function idasol(f,
     flag = @checkflag IDASetUserData(mem, userfun) true
     flag = @checkflag IDASStolerances(mem, reltol, abstol) true
 
-    A = Sundials.SUNDenseMatrix(length(y0), length(y0), ctx)
+    A = Sundials.SUNDenseMatrix(Int64(length(y0)), Int64(length(y0)), ctx)
     LS = Sundials.SUNLinSol_Dense(y0nv, A, ctx)
     flag = Sundials.@checkflag Sundials.IDADlsSetLinearSolver(mem, LS, A) true
 


### PR DESCRIPTION
## Summary

Fixes x86 (32-bit) compatibility issues by explicitly converting `Int` to `Int64` where needed for Sundials C API calls.

## Problem

On x86 (32-bit) systems, `Int` is `Int32`, but the Sundials C API expects `sunindextype` which is defined as `Int64`. This causes `MethodError`:

```
MethodError: no method matching N_VMake_Serial(::Int32, ::Vector{Float64}, ::Ptr{Nothing})
The function `N_VMake_Serial` exists, but no method is defined for this combination of argument types.
Closest candidates are:
  N_VMake_Serial(::Int64, ::Any, ::Ptr{Nothing})
```

## Solution

Added explicit `Int64()` conversions for all `length()` calls and integer parameters passed to Sundials C API functions:

### Files changed:
- **src/nvector_wrapper.jl**: Convert `length(v)` to `Int64` in `N_VMake_Serial` call
- **src/common_interface/solve.jl**: Convert all `length(uvec)`, `length(u0)`, and bandwidth parameters to `Int64` for matrix constructors
- **src/simple.jl**: Convert all `length(y0)` and bandwidth parameters to `Int64` for matrix constructors

### Functions affected:
- `N_VMake_Serial(length(v), ...)` → `N_VMake_Serial(Int64(length(v)), ...)`
- `SUNDenseMatrix(length(...), length(...), ...)` → `SUNDenseMatrix(Int64(length(...)), Int64(length(...)), ...)`
- `SUNBandMatrix(length(...), upper, lower, ...)` → `SUNBandMatrix(Int64(length(...)), Int64(upper), Int64(lower), ...)`
- `SUNSparseMatrix(length(...), length(...), nnz, ...)` → `SUNSparseMatrix(Int64(length(...)), Int64(length(...)), Int64(nnz), ...)`

## Test plan

- [x] Local build succeeds
- [ ] CI x86 tests pass

Fixes CI failure: https://github.com/SciML/Sundials.jl/actions/runs/17394622855/job/49374121057?pr=493

🤖 Generated with [Claude Code](https://claude.ai/code)