### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "5.1.0"
+version = "5.2.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -44,7 +44,7 @@ ODEProblemLibrary = "1"
 PrecompileTools = "1"
 Reexport = "1.0"
 SafeTestsets = "0.1"
-SciMLBase = "2.119.0"
+SciMLBase = "2.119.0, 3"
 SparseArrays = "1"
 SparseConnectivityTracer = "1"
 Sundials_jll = "7.4.1"


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version (minor): 5.1.0 → 5.2.0
- No code changes needed - DiffEqBase.u_modified! still works as deprecated in v3
- Supersedes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)