### PR TITLE
Replace deprecated u_modified! with derivative_discontinuity!

### DIFF
--- a/src/Sundials.jl
+++ b/src/Sundials.jl
@@ -9,7 +9,7 @@ using DiffEqBase: DiffEqBase, NonlinearFunction, ODEFunction, add_saveat!,
     check_keywords, get_du, get_du!, get_tmp_cache, get_tstops,
     get_tstops_array, initialize!, isinplace,
     reeval_internals_due_to_modification!, reinit!, savevalues!,
-    set_proposed_dt!, solve, solve!, step!, terminate!, u_modified!,
+    set_proposed_dt!, solve, solve!, step!, terminate!,
     update_coefficients!, warn_compat, DefaultInit, BrownFullBasicInit,
     ShampineCollocationInit
 using SciMLBase: AbstractSciMLOperator, DAEProblem, ODEProblem, ReturnCode,

--- a/src/common_interface/integrator_utils.jl
+++ b/src/common_interface/integrator_utils.jl
@@ -212,8 +212,14 @@ end
 
 DiffEqBase.get_tmp_cache(integrator::AbstractSundialsIntegrator) = (integrator.tmp,)
 
-@inline function DiffEqBase.u_modified!(integrator::AbstractSundialsIntegrator, bool::Bool)
-    return integrator.u_modified = bool
+if isdefined(SciMLBase, :derivative_discontinuity!)
+    @inline function SciMLBase.derivative_discontinuity!(integrator::AbstractSundialsIntegrator, bool::Bool)
+        return integrator.u_modified = bool
+    end
+else
+    @inline function DiffEqBase.u_modified!(integrator::AbstractSundialsIntegrator, bool::Bool)
+        return integrator.u_modified = bool
+    end
 end
 
 function DiffEqBase.terminate!(


### PR DESCRIPTION
## Summary
- Replace `DiffEqBase.u_modified!` dispatch with `SciMLBase.derivative_discontinuity!` for SciMLBase v3 compatibility
- Uses `isdefined(SciMLBase, :derivative_discontinuity!)` to conditionally define the right method, maintaining backward compatibility with SciMLBase v2
- Removes unused `u_modified!` import from `DiffEqBase`
- Follows up on #521 which bumped SciMLBase compat to v3 but left the deprecated API in place

## Test plan
- [x] Verified precompilation succeeds with SciMLBase v2 (current resolver constraint)
- [x] Ran callback, iterator, IDA, CVODE, and ARKODE common interface tests — all pass
- [x] Runic formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)