### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "5.2.0"
+version = "5.3.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -30,7 +30,7 @@ ArrayInterface = "7.17.1"
 CEnum = "0.5"
 DAEProblemLibrary = "0.1"
 DataStructures = "0.18, 0.19"
-DiffEqBase = "6.217"
+DiffEqBase = "6.217, 7"
 DiffEqCallbacks = "4"
 DifferentiationInterface = "0.6, 0.7"
 ForwardDiff = "0.10"


### PR DESCRIPTION
## Summary

Widen `DiffEqBase = "6.217"` → `"6.217, 7"` so Sundials resolves alongside `lib/DiffEqBase` v7.0.0 (OrdinaryDiffEq v7 release). Bumps 5.2.0 → 5.3.0.

Already-OK: `SciMLBase = "2.119.0, 3"`, `DiffEqCallbacks = "4"`.

## Why this is source-level safe

Grepped `src/` and `ext/` for every removed v7 / SciMLBase v3 symbol:

- `DiffEqBase.u_modified!(integrator::AbstractSundialsIntegrator, bool)` at `src/common_interface/integrator_utils.jl:215` still works — SciMLBase v3 keeps `u_modified!` as `@deprecate u_modified!(i, bool) derivative_discontinuity!(i, bool)` (scheduled removal 2028), so adding a method to it is valid. Will emit a deprecation warning on v3; mechanical swap to `SciMLBase.derivative_discontinuity!` is a reasonable follow-up.
- `SciMLBase.DEStats(0)` at three sites in `src/common_interface/solve.jl` (lines 469, 1054, 1461) — `DEStats` was NOT removed in SciMLBase v3 (only the `DiffEqBase.DEStats` re-export was removed); the `SciMLBase.DEStats` struct is still defined and exported.
- No hits for `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `QuadratureProblem`, `tuples()`/`intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`.

## Scope

Not a direct blocker of OrdinaryDiffEq.jl#3488's test matrix (Sundials isn't an OrdinaryDiffEq test dep), but part of the same v7-compat-widening set as DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431 — needed so downstream users can install Sundials together with the v7 stack once it lands.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>