### PR TITLE
Bump major version (5.3.0 → 6.0.0) for SciMLBase v3 / DiffEqBase v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "5.3.0"
+version = "6.0.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

The SciMLBase v3 / DiffEqBase v7 / OrdinaryDiffEq v7 release is **breaking** across the ecosystem (typed `verbose` / `DEVerbosity` instead of `Bool`, `AutoSpecialize` `ODEFunction` default, controllers as objects, RAT v4, removed re-exports, etc. — see [the OrdinaryDiffEq v7 NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)).

`master` already widened compat to include SciMLBase v3 / DiffEqBase v7, but the latest registered version is still on the prior major. Per SemVer, that ecosystem upgrade should ride a major bump so users opt into v3 explicitly rather than getting it via a routine update.

The package source already runs against both the v2 and v3 ecosystems (compat covers both), so no code changes are needed — this is a version-only bump. Companion PRs landed for DASKR, DASSL, IRKGaussLegendre, and ODEInterfaceDiffEq, with their pre-major v3-allowing releases yanked in https://github.com/JuliaRegistries/General/pull/153846.

## Test plan
- [ ] CI green
- [ ] After merge, register with `@JuliaRegistrator register()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)