### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
+      - "/gen"
+      - "/test/jet"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,21 +12,9 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        continue-on-error: true
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: true
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: true
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -75,3 +75,5 @@ SDE = "SDE"
 # Sundials-specific terms
 yout = "yout"  # y output (legitimate variable name in Sundials API)
 ypout = "ypout"  # y-prime output (derivative output)
+wrk = "wrk"  # work-array argument name in generated C bindings (lib/libsundials_api.jl)
+BCK = "BCK"  # Sundials C constant suffix, e.g. CV_NO_BCK / IDA_NO_BCK (lib/libsundials_common.jl)

--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -157,7 +157,7 @@ function wrap_sundials_api(expr::Expr)
             end
             # generate a higher-level wrapper that converts 1st arg to XXXMemPtr
             # and all other args from Julia objects to low-level C wrappers (e.g. NVector to N_Vector)
-            # create wrapers for all arguments that need wrapping
+            # create wrappers for all arguments that need wrapping
             args_wrap_exprs = map(Base.Iterators.drop(expr.args[1].args, 1)) do expr
                 # process each argument
                 # return a tuple:

--- a/test/cvodes_dns.jl
+++ b/test/cvodes_dns.jl
@@ -118,7 +118,7 @@ end
 ## cvodes wrapper
 
 "Given the sensitivity problem, return (y,ys) where
-y[i,t] is the solutions i-th componnent for timestep t and
+y[i,t] is the solutions i-th component for timestep t and
 ys[i,j,t] is the sensitivity of the i-th component wrt to the j-th parameter, where
 the last parameter indices correspond to the initial conditions components."
 function cvodes(f, fS, t0, y0, yS0, p, reltol, abstol, pbar, t::AbstractVector)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI checks to the centralized SciML reusable workflows (all pinned `@v1`, every caller gets `secrets: "inherit"`). Preserves each workflow file's `name:`/`on:`/`concurrency:` and the existing behavior.

## Converted (inline -> central caller)
- **Runic** (`FormatCheck.yml`): `fredrikekre/runic-action` -> `runic.yml@v1`. Runic ran clean on the full tree (including the generated `lib/*.jl`), so no `exclude:` was needed and no formatting changes were required.
- **SpellCheck** (`SpellCheck.yml`): `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`.
- **Downgrade** (`Downgrade.yml`): inline downgrade job -> `downgrade.yml@v1` with `julia-version: "1.10"`, `skip: "Pkg,TOML"`, `allow-reresolve: true` (matches the previous `1.10` / `alldeps` / `Pkg,TOML` / `allow_reresolve: true` setup).

## Left as-is
- **Tests** (`Tests.yml`): already a `tests.yml@v1` caller with `secrets: inherit` and the full version x os x arch matrix. Untouched.
- **QA** (`QA.yml`): JET tests, not one of the centralized checks. Untouched.
- **TagBot** (`TagBot.yml`): untouched per policy.
- No Documentation caller added (repo has no `docs/`). No Downstream/Benchmark/CompatHelper present, so none added/removed there.

## Typos
- 2 prose typos auto-fixed by `typos -w`: `wrapers` -> `wrappers` (`gen/generate.jl` comment), `componnent` -> `component` (`test/cvodes_dns.jl` docstring).
- Exempted two generated-binding identifiers in `.typos.toml` (domain false-positives, not prose edits): `wrk` (work-array arg in `lib/libsundials_api.jl`) and `BCK` (Sundials C constant suffix, e.g. `CV_NO_BCK` / `IDA_NO_BCK` in `lib/libsundials_common.jl`).
- `typos .` now exits 0.

## dependabot.yml
- Removed the `crate-ci/typos` ignore (now managed centrally).
- Kept the `github-actions` block (`directory: "/"`, weekly).
- Julia block (daily, group `all-julia-packages: ["*"]`) now lists the dirs that actually contain a `Project.toml`: `/`, `/gen`, `/test/jet` (previously `/` and a nonexistent `/test`).

## Heads-up
The check **names change** with the central callers (the reusable workflows define their own job names). Branch-protection required-status-check names will need updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)