### PR TITLE
Wrap CVODES sensitivity paths in tests

### DIFF
--- a/src/nvector_wrapper.jl
+++ b/src/nvector_wrapper.jl
@@ -86,6 +86,32 @@ Conversion happens in two steps within ccall:
 Base.cconvert(::Type{N_Vector}, nv::NVector) = nv
 Base.unsafe_convert(::Type{N_Vector}, nv::NVector) = nv.n_v
 
+"""
+    NVectorArray(nvectors)
+
+Keep a vector of `NVector`s and the corresponding `N_Vector*` pointer array
+alive together for SUNDIALS APIs that take arrays of `N_Vector`.
+"""
+struct NVectorArray <: AbstractVector{N_Vector}
+    nvectors::Vector{NVector}
+    ptrs::Vector{N_Vector}
+end
+
+function NVectorArray(nvectors::AbstractVector{<:NVector})
+    owned_nvectors = collect(nvectors)
+    return NVectorArray(
+        owned_nvectors,
+        N_Vector[Base.unsafe_convert(N_Vector, nv) for nv in owned_nvectors],
+    )
+end
+
+Base.size(nva::NVectorArray) = size(nva.ptrs)
+Base.IndexStyle(::Type{<:NVectorArray}) = IndexLinear()
+Base.getindex(nva::NVectorArray, i::Int) = getindex(nva.ptrs, i)
+Base.pointer(nva::NVectorArray) = pointer(nva.ptrs)
+Base.cconvert(::Type{Ptr{N_Vector}}, nva::NVectorArray) = nva
+Base.unsafe_convert(::Type{Ptr{N_Vector}}, nva::NVectorArray) = pointer(nva)
+
 Base.similar(nv::NVector) = NVector(similar(nv.v), nv.ctx)
 
 nvlength(x::N_Vector) = unsafe_load(unsafe_load(convert(Ptr{Ptr{Clong}}, x)))

--- a/test/cvodes_adjoint.jl
+++ b/test/cvodes_adjoint.jl
@@ -1,0 +1,129 @@
+using Sundials, Test
+using Sundials: N_Vector
+
+ctx_ref = Ref{Sundials.SUNContext}(C_NULL)
+Sundials.SUNContext_Create(C_NULL, Base.unsafe_convert(Ptr{Sundials.SUNContext}, ctx_ref))
+ctx = ctx_ref[]
+
+mutable struct CVAdjointData
+    a::Float64
+end
+
+function cv_forward_rhs(t::Float64, y::N_Vector, ydot::N_Vector, data::CVAdjointData)
+    ydotv = convert(Vector, ydot)
+    yv = convert(Vector, y)
+    ydotv[1] = data.a * yv[1]
+    return Sundials.CV_SUCCESS
+end
+
+function cv_adjoint_rhs(
+        t::Float64,
+        y::N_Vector,
+        yB::N_Vector,
+        yBdot::N_Vector,
+        data::CVAdjointData
+    )
+    yBdotv = convert(Vector, yBdot)
+    yBv = convert(Vector, yB)
+    yBdotv[1] = -data.a * yBv[1]
+    return Sundials.CV_SUCCESS
+end
+
+function cv_adjoint_quad_rhs(
+        t::Float64,
+        y::N_Vector,
+        yB::N_Vector,
+        qBdot::N_Vector,
+        data::CVAdjointData
+    )
+    yv = convert(Vector, y)
+    yBv = convert(Vector, yB)
+    qBdotv = convert(Vector, qBdot)
+    qBdotv[1] = -yBv[1] * yv[1]
+    return Sundials.CV_SUCCESS
+end
+
+function solve_adjoint(; t0 = 0.0, tf = 2.0, y0 = 2.0, a = 0.3)
+    data = CVAdjointData(a)
+
+    cfwd = @cfunction(
+        cv_forward_rhs,
+        Cint,
+        (Sundials.realtype, N_Vector, N_Vector, Ref{CVAdjointData})
+    )
+    cadj = @cfunction(
+        cv_adjoint_rhs,
+        Cint,
+        (Sundials.realtype, N_Vector, N_Vector, N_Vector, Ref{CVAdjointData})
+    )
+    cadj_quad = @cfunction(
+        cv_adjoint_quad_rhs,
+        Cint,
+        (Sundials.realtype, N_Vector, N_Vector, N_Vector, Ref{CVAdjointData})
+    )
+
+    y0v = [y0]
+    yf = similar(y0v)
+    y0n = Sundials.NVector(y0v, ctx)
+    yfn = Sundials.NVector(yf, ctx)
+    tret = [t0]
+    ncheck = Ref{Cint}(0)
+
+    cvode_mem = Sundials.Handle(Sundials.CVodeCreate(Sundials.CV_ADAMS, ctx))
+    nls = Sundials.SUNNonlinSol_FixedPoint(y0n, Cint(0), ctx)
+    nls_handle = Sundials.NonLinSolHandle(nls, Sundials.FixedPoint())
+
+    @test Sundials.CVodeInit(cvode_mem, cfwd, t0, y0n) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeSetUserData(cvode_mem, data) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeSetNonlinearSolver(cvode_mem, nls) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeSStolerances(cvode_mem, 1.0e-10, 1.0e-12) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeAdjInit(cvode_mem, 50, Sundials.CV_HERMITE) == Sundials.CV_SUCCESS
+
+    @test Sundials.CVodeF(cvode_mem, tf, yfn, tret, Sundials.CV_NORMAL, ncheck) ==
+        Sundials.CV_SUCCESS
+
+    which = Ref{Cint}(0)
+    @test Sundials.CVodeCreateB(cvode_mem, Sundials.CV_ADAMS, which) == Sundials.CV_SUCCESS
+
+    yB0 = [1.0]
+    yB0n = Sundials.NVector(yB0, ctx)
+    yBout = similar(yB0)
+    yBoutn = Sundials.NVector(yBout, ctx)
+    qB0 = [0.0]
+    qB0n = Sundials.NVector(qB0, ctx)
+    qBout = similar(qB0)
+    qBoutn = Sundials.NVector(qBout, ctx)
+    tBret = [tf]
+    nlsB = Sundials.SUNNonlinSol_FixedPoint(yB0n, Cint(0), ctx)
+    nlsB_handle = Sundials.NonLinSolHandle(nlsB, Sundials.FixedPoint())
+
+    @test Sundials.CVodeInitB(cvode_mem, which[], cadj, tf, yB0n) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeSetUserDataB(cvode_mem, which[], data) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeSetNonlinearSolverB(cvode_mem, which[], nlsB) == Sundials.CV_SUCCESS
+    @test Sundials.CVodeSStolerancesB(cvode_mem, which[], 1.0e-10, 1.0e-12) ==
+        Sundials.CV_SUCCESS
+    @test Sundials.CVodeQuadInitB(cvode_mem, which[], cadj_quad, qB0n) ==
+        Sundials.CV_SUCCESS
+    @test Sundials.CVodeQuadSStolerancesB(cvode_mem, which[], 1.0e-10, 1.0e-12) ==
+        Sundials.CV_SUCCESS
+
+    GC.@preserve data y0n yfn yB0n yBoutn qB0n qBoutn nls_handle nlsB_handle begin
+        @test Sundials.CVodeB(cvode_mem, t0, Sundials.CV_NORMAL) >= Sundials.CV_SUCCESS
+        @test Sundials.CVodeGetB(cvode_mem, which[], tBret, yBoutn) == Sundials.CV_SUCCESS
+        @test Sundials.CVodeGetQuadB(cvode_mem, which[], tBret, qBoutn) == Sundials.CV_SUCCESS
+    end
+
+    empty!(nlsB_handle)
+    empty!(nls_handle)
+    empty!(cvode_mem)
+    Sundials.SUNContext_Free(ctx)
+
+    return yf[1], yBout[1], qBout[1], tBret[1]
+end
+
+yf, lambda0, grad_a, tBret = solve_adjoint()
+
+@test isapprox(yf, 2.0 * exp(0.3 * 2.0); rtol = 1.0e-8)
+@test isapprox(lambda0, exp(0.3 * 2.0); rtol = 1.0e-8)
+@test isapprox(grad_a, 2.0 * yf; rtol = 1.0e-8)
+@test isapprox(tBret, 0.0; atol = 1.0e-12)

--- a/test/cvodes_dns.jl
+++ b/test/cvodes_dns.jl
@@ -76,7 +76,7 @@ end
 
 ## data structure dealing with the sundials callbacks
 
-struct CVSData
+mutable struct CVSData
     f::Any  # f(t,y,dy)
     fs::Any # fs()
     p::Any
@@ -128,9 +128,10 @@ function cvodes(f, fS, t0, y0, yS0, p, reltol, abstol, pbar, t::AbstractVector)
     tret = [t0]
     yret = similar(y0)
     ysret = similar(yS0)
+    y0n = Sundials.NVector(y0, ctx)
+    yretn = Sundials.NVector(yret, ctx)
     yS0n = [Sundials.NVector(yS0[:, j], ctx) for j in 1:Ns]
-    yS0nv = [N_Vector(n) for n in yS0n]
-    pyS0 = pointer(yS0nv)
+    yS0nv = Sundials.NVectorArray(yS0n)
     crhs = Sundials.@cfunction(
         cvrhsfn,
         Cint,
@@ -157,23 +158,31 @@ function cvodes(f, fS, t0, y0, yS0, p, reltol, abstol, pbar, t::AbstractVector)
     mem_ptr = Sundials.CVodeCreate(Sundials.CV_ADAMS, ctx)
     #mem_ptr = Sundials.CVodeCreate(Sundials.CV_BDF, ctx)
     cvode_mem = Sundials.Handle(mem_ptr)
-    Sundials.CVodeInit(cvode_mem, crhs, t0, convert(NVector, y0))
+    Sundials.CVodeInit(cvode_mem, crhs, t0, y0n)
+    nls = Sundials.SUNNonlinSol_FixedPoint(yretn, Cint(0), ctx)
+    nls_handle = Sundials.NonLinSolHandle(nls, Sundials.FixedPoint())
+    Sundials.CVodeSetNonlinearSolver(cvode_mem, nls)
     Sundials.CVodeSStolerances(cvode_mem, reltol, abstol)
-    Sundials.CVodeSetUserData(cvode_mem, CVSData(f, fS, p, size(yS0)...))
+    data = CVSData(f, fS, p, size(yS0)...)
+    Sundials.CVodeSetUserData(cvode_mem, data)
 
-    Sundials.CVodeSensInit(cvode_mem, Ns, Sundials.CV_STAGGERED, csensrhs, pyS0)
+    Sundials.CVodeSensInit(cvode_mem, Ns, Sundials.CV_STAGGERED, csensrhs, yS0nv)
+    nlsS = Sundials.SUNNonlinSol_FixedPointSens(Cint(Ns), yretn, Cint(0), ctx)
+    nlsS_handle = Sundials.NonLinSolHandle(nlsS, Sundials.FixedPoint())
+    Sundials.CVodeSetNonlinearSolverSensStg(cvode_mem, nlsS)
     Sundials.CVodeSetSensParams(cvode_mem, C_NULL, pbar, C_NULL)
     Sundials.CVodeSensEEtolerances(cvode_mem)
-    for i in 1:length(t)
-        @info "here1"
-        Sundials.CVode(cvode_mem, t[i], yret, tret, Sundials.CV_NORMAL)
-        @info "here2"
-        Sundials.CVodeGetSens(cvode_mem, tret, pyS0)
-        @info "here3"
-        mycopy!(pyS0, ysret)
-        y[:, i] = yret
-        ys[:, :, i] = ysret
+    GC.@preserve data y0n yretn yS0n yS0nv pbar nls_handle nlsS_handle begin
+        for i in 1:length(t)
+            Sundials.CVode(cvode_mem, t[i], yretn, tret, Sundials.CV_NORMAL)
+            Sundials.CVodeGetSens(cvode_mem, tret, yS0nv)
+            mycopy!(pointer(yS0nv), ysret)
+            y[:, i] = yret
+            ys[:, :, i] = ysret
+        end
     end
+    empty!(nlsS_handle)
+    empty!(nls_handle)
     empty!(cvode_mem)
     return y, ys
 end
@@ -183,8 +192,8 @@ t = [1.0, 2.0]
 y0 = [1.0, 2.0]
 p = [3.0, 4.0]
 y, ys = sens(f!, t0, y0, p, t)
-@test_broken isapprox(y[1, 1], 20.0856; rtol = 1.0e-3)
-@test_broken isapprox(ys[2, 2, 2], 11924.3; rtol = 1.0e-3) # todo: check if these are indeed the right results
+@test isapprox(y[1, 1], 20.0856; rtol = 1.0e-3)
+@test isapprox(ys[2, 2, 2], 11924.3; rtol = 1.0e-3)
 
 # Clean up context
 Sundials.SUNContext_Free(ctx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,9 @@ end
     @safetestset "CVODES Direct" begin
         include("cvodes_dns.jl")
     end
+    @safetestset "CVODES Adjoint" begin
+        include("cvodes_adjoint.jl")
+    end
 end
 
 @testset "IDA" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,9 @@ end
     @safetestset "Roberts CVODE Direct" begin
         include("cvode_Roberts_dns.jl")
     end
-    #@testset "CVODES Direct" begin include("cvodes_dns.jl") end
+    @safetestset "CVODES Direct" begin
+        include("cvodes_dns.jl")
+    end
 end
 
 @testset "IDA" begin


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Add `NVectorArray` support for arrays of `N_Vector` values so CVODES forward sensitivity setup can pass the expected pointer shape.
- Enable and fix the direct CVODES sensitivity test in `cvodes_dns.jl`.
- Add a CVODES adjoint sensitivity test covering reverse sensitivity with backward quadrature.

## Context

Sundials.jl had low-level CVODES sensitivity entry points available from the JLL, but the Julia wrapper/test coverage did not exercise the forward sensitivity vector-array path or the adjoint path. The forward path needed a wrapper object that keeps the individual `NVector`s and pointer storage alive while passing a `Ptr{N_Vector}` to SUNDIALS.

The adjoint test solves a scalar `y' = a*y` problem, then integrates the backward adjoint and quadrature equation. It checks the adjoint initial value and the parameter gradient against the analytic values.

## Local validation

- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); include("test/cvodes_dns.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); include("test/cvodes_adjoint.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add("Runic"); using Runic; exit(Runic.main(["--check", "."]))'`
- `git diff --check`

## Process notes

The work was split into two commits: one for the forward sensitivity wrapper/test path and one for the adjoint sensitivity test.