### PR TITLE
Document Sundials public API

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
+
+[sources]
+Sundials = { path = ".." }
+
+[compat]
+Documenter = "1"
+Sundials = "6"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,23 @@
+using Documenter, Sundials
+
+DocMeta.setdocmeta!(
+    Sundials, :DocTestSetup, :(using Sundials); recursive = true
+)
+
+makedocs(
+    sitename = "Sundials.jl",
+    authors = "Chris Rackauckas",
+    clean = true,
+    doctest = false,
+    format = Documenter.HTML(
+        canonical = "https://docs.sciml.ai/Sundials/stable/"
+    ),
+    pages = [
+        "Home" => "index.md",
+    ]
+)
+
+deploydocs(
+    repo = "github.com/SciML/Sundials.jl";
+    push_preview = true
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,43 @@
+# Sundials.jl
+
+Sundials.jl provides SciML common-interface wrappers for the SUNDIALS C library,
+including CVODE, ARKODE, IDA, and KINSOL algorithms.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("Sundials")
+```
+
+## Usage
+
+```julia
+using Sundials
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0 * (u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return nothing
+end
+
+prob = ODEProblem(lorenz!, [1.0, 0.0, 0.0], (0.0, 100.0))
+sol = solve(prob, CVODE_Adams())
+```
+
+## API
+
+```@docs
+CVODE_BDF
+CVODE_Adams
+ARKODE
+IDA
+KINSOL
+SundialsODEAlgorithm
+SundialsDAEAlgorithm
+solve
+DefaultInit
+BrownFullBasicInit
+ShampineCollocationInit
+```

--- a/src/common_interface/algorithms.jl
+++ b/src/common_interface/algorithms.jl
@@ -1,8 +1,47 @@
 # Sundials.jl algorithms
 
 # Abstract Types
+"""
+    SundialsODEAlgorithm{Method, LinearSolver}
+
+Abstract supertype for Sundials-backed ODE algorithm values.
+
+# Arguments
+- `Method`: Sundials nonlinear iteration choice encoded in the algorithm type, such as
+  `:Newton` or `:Functional`.
+- `LinearSolver`: Sundials linear solver choice encoded in the algorithm type, such as
+  `:Dense`, `:Band`, `:GMRES`, or `:KLU`.
+
+# Returns
+Concrete subtypes, such as [`CVODE_BDF`](@ref), [`CVODE_Adams`](@ref), and
+[`ARKODE`](@ref), are algorithm objects passed to `solve`.
+
+# Interface Notes
+This type is part of the SciML common solve interface. Downstream extensions should dispatch
+on concrete algorithm types when they need solver-specific options, and on
+`SundialsODEAlgorithm` only for behavior shared by all Sundials ODE algorithms.
+"""
 abstract type SundialsODEAlgorithm{Method, LinearSolver} <: SciMLBase.AbstractODEAlgorithm end
+
+"""
+    SundialsDAEAlgorithm{LinearSolver}
+
+Abstract supertype for Sundials-backed DAE algorithm values.
+
+# Arguments
+- `LinearSolver`: Sundials linear solver choice encoded in the algorithm type, such as
+  `:Dense`, `:Band`, `:GMRES`, or `:KLU`.
+
+# Returns
+Concrete subtypes, such as [`IDA`](@ref), are algorithm objects passed to `solve`.
+
+# Interface Notes
+This type is part of the SciML common solve interface. Downstream extensions should dispatch
+on concrete algorithm types when they need solver-specific options, and on
+`SundialsDAEAlgorithm` only for behavior shared by all Sundials DAE algorithms.
+"""
 abstract type SundialsDAEAlgorithm{LinearSolver} <: SciMLBase.AbstractDAEAlgorithm end
+
 abstract type SundialsNonlinearSolveAlgorithm{LinearSolver} <:
 SciMLBase.AbstractNonlinearAlgorithm end
 

--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -1,0 +1,167 @@
+using Sundials, Test
+
+function _strip_comment(line)
+    io = IOBuffer()
+    in_string = false
+    quotechar = '\0'
+    escaped = false
+
+    for char in line
+        if escaped
+            print(io, char)
+            escaped = false
+        elseif char == '\\'
+            print(io, char)
+            escaped = true
+        elseif in_string
+            print(io, char)
+            char == quotechar && (in_string = false)
+        elseif char == '"' || char == '\''
+            print(io, char)
+            in_string = true
+            quotechar = char
+        elseif char == '#'
+            break
+        else
+            print(io, char)
+        end
+    end
+
+    return String(take!(io))
+end
+
+function _public_names_from_statement(statement)
+    normalized = replace(statement, r"^\s*(export|public|@public|SciMLPublic\.@public)\s+" => "")
+    normalized = replace(normalized, r"\b(export|public)\b" => "")
+    normalized = replace(normalized, "SciMLPublic.@public" => "")
+    normalized = replace(normalized, "@public" => "")
+    normalized = replace(normalized, r"Expr\s*\(\s*:public\s*,?" => "")
+    normalized = replace(normalized, r"eval\s*\(" => "")
+    normalized = replace(normalized, r"Symbol\s*\(\s*\"(@?[A-Za-z_][A-Za-z0-9_!]*)\"\s*\)" => s"\1")
+    normalized = replace(normalized, ')' => " ")
+    normalized = replace(normalized, ':' => "")
+
+    public_names = Symbol[]
+    for token in split(normalized, [',', ' ', '\t', '\n'])
+        name = strip(token)
+        isempty(name) && continue
+        occursin(r"^@?[A-Za-z_][A-Za-z0-9_!]*$", name) || continue
+        name in ("return", "symbols", "symbols_expr") && continue
+        push!(public_names, Symbol(name))
+    end
+
+    return public_names
+end
+
+function _source_public_names()
+    public_names = Symbol[]
+
+    for src_dir in ("src", "lib")
+        src_root = normpath(joinpath(@__DIR__, "..", "..", src_dir))
+        isdir(src_root) || continue
+
+        for (root, _, files) in walkdir(src_root)
+            for file in files
+                endswith(file, ".jl") || continue
+                path = joinpath(root, file)
+                lines = readlines(path)
+                in_docstring = false
+                line_index = 1
+
+                while line_index <= length(lines)
+                    line = lines[line_index]
+                    if occursin("\"\"\"", line)
+                        in_docstring = !in_docstring
+                        count("\"\"\"", line) >= 2 && (in_docstring = !in_docstring)
+                    end
+
+                    raw = in_docstring ? "" : _strip_comment(line)
+                    stripped = strip(raw)
+                    if startswith(stripped, "export ") ||
+                            startswith(stripped, "public ") ||
+                            startswith(stripped, "@public ") ||
+                            startswith(stripped, "SciMLPublic.@public ") ||
+                            occursin("Expr(:public", stripped) ||
+                            occursin("Expr(:(public)", stripped)
+                        statement = raw
+                        parens = count(==('('), statement) - count(==(')'), statement)
+                        while (endswith(rstrip(statement), ",") || parens > 0) &&
+                                line_index < length(lines)
+                            line_index += 1
+                            statement *= " " * _strip_comment(lines[line_index])
+                            parens = count(==('('), statement) - count(==(')'), statement)
+                        end
+                        append!(public_names, _public_names_from_statement(statement))
+                    end
+
+                    line_index += 1
+                end
+            end
+        end
+    end
+
+    return sort!(unique(public_names))
+end
+
+function _rendered_docs_entries()
+    docs_root = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+    entries = Set{Symbol}()
+
+    for (root, _, files) in walkdir(docs_root)
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs_block = false
+            for line in eachline(joinpath(root, file))
+                stripped = strip(line)
+                if stripped == "```@docs"
+                    in_docs_block = true
+                    continue
+                elseif startswith(stripped, "```")
+                    in_docs_block = false
+                    continue
+                end
+
+                in_docs_block || continue
+                isempty(stripped) && continue
+                startswith(stripped, "#") && continue
+                identifier = replace(stripped, r"\(.*" => "")
+                identifier = split(identifier, ".")[end]
+                isempty(identifier) || push!(entries, Symbol(identifier))
+            end
+        end
+    end
+
+    return entries
+end
+
+function _binding_owner(mod::Module, name::Symbol)
+    return parentmodule(getfield(mod, name))
+end
+
+function _has_docstring(mod::Module, name::Symbol)
+    return haskey(Docs.meta(mod), Docs.Binding(mod, name))
+end
+
+@testset "Sundials public API documentation coverage" begin
+    source_public_names = _source_public_names()
+    source_owned_public_names = filter(
+        name -> _binding_owner(Sundials, name) === Sundials,
+        source_public_names
+    )
+    owned_exports = filter(sort!(collect(names(Sundials; all = false)))) do name
+        name !== :Sundials &&
+            isdefined(Sundials, name) &&
+            _binding_owner(Sundials, name) === Sundials
+    end
+
+    @test source_owned_public_names == owned_exports
+
+    undocumented = filter(source_public_names) do name
+        !_has_docstring(_binding_owner(Sundials, name), name)
+    end
+    @test isempty(undocumented)
+
+    rendered_entries = _rendered_docs_entries()
+    missing_rendered = filter(name -> name ∉ rendered_entries, source_public_names)
+    @test isempty(missing_rendered)
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, Sundials, Test
 using JET
 
+include("public_api_docs.jl")
+
 # ExplicitImports ignore-lists below are all names owned by / non-public in OTHER
 # packages that Sundials legitimately uses; they will stop being flagged once those
 # upstream packages mark them public.


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Add source-site docstrings for the Sundials-owned exported abstract algorithm supertypes.
- Add a minimal Documenter docs tree with `@docs` entries for the declared public/exported Sundials API.
- Add focused QA coverage that scans source `export`/`public`/`@public`/`SciMLPublic.@public` declarations, verifies source-site docstrings, and verifies rendered docs entries.

## Validation
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_sundials /home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -m Runic -i src/common_interface/algorithms.jl test/qa/qa.jl test/qa/public_api_docs.jl docs/make.jl`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_sundials /home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -m Runic --check src/common_interface/algorithms.jl test/qa/qa.jl test/qa/public_api_docs.jl docs/make.jl`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_sundials /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_sundials /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate(); include("docs/make.jl")'`
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_051717_3275/.julia_depot_sundials /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`