### PR TITLE
Unify solution interpolation via SciMLBase.BasicInterpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "6.3.0"
+version = "6.4.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -45,7 +45,7 @@ ODEProblemLibrary = "1"
 PrecompileTools = "1"
 Reexport = "1.0"
 SafeTestsets = "0.1"
-SciMLBase = "2.119.0, 3"
+SciMLBase = "3.35"
 SciMLLogging = "1.10.1, 2"
 SparseArrays = "1"
 SparseConnectivityTracer = "1"

--- a/src/common_interface/solve.jl
+++ b/src/common_interface/solve.jl
@@ -459,12 +459,7 @@ function DiffEqBase.__init(
         ts,
         ures;
         dense = dense,
-        interp = dense ?
-            SciMLBase.HermiteInterpolation(
-                ts, ures,
-                dures
-            ) :
-            SciMLBase.LinearInterpolation(ts, ures),
+        interp = SciMLBase.BasicInterpolation(ts, ures, dures, dense),
         timeseries_errors = timeseries_errors,
         stats = SciMLBase.DEStats(0),
         calculate_error = false
@@ -1044,12 +1039,7 @@ function DiffEqBase.__init(
         ts,
         ures;
         dense = dense,
-        interp = dense ?
-            SciMLBase.HermiteInterpolation(
-                ts, ures,
-                dures
-            ) :
-            SciMLBase.LinearInterpolation(ts, ures),
+        interp = SciMLBase.BasicInterpolation(ts, ures, dures, dense),
         timeseries_errors = timeseries_errors,
         stats = SciMLBase.DEStats(0),
         calculate_error = false
@@ -1453,8 +1443,9 @@ function DiffEqBase.__init(
         prob,
         alg,
         ts,
-        ures, dense ? dures : nothing;
+        ures, dures;
         dense = dense,
+        interp = SciMLBase.BasicInterpolation(ts, ures, dures, dense),
         calculate_error = false,
         timeseries_errors = timeseries_errors,
         retcode = retcode,

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -1,4 +1,4 @@
-using Sundials, Test, DiffEqBase
+using Sundials, Test, DiffEqBase, SciMLBase
 using ForwardDiff
 import ODEProblemLibrary: prob_ode_linear, prob_ode_2Dlinear
 
@@ -24,3 +24,94 @@ end
 regression_test(ARKODE(), 1.0e-5, 1.5e-3)  # Relaxed from 1e-4 to 1.5e-3 for 2D problem
 regression_test(CVODE_BDF(), 1.0e-5, 1.0e-2)  # Relaxed from 1e-6 to 1e-5 for numerical stability
 regression_test(CVODE_Adams(), 1.0e-5, 1.0e-3)  # Relaxed from 1e-6 to 1e-5 for numerical stability
+
+# The solution's concrete type must NOT depend on whether the solve was dense.
+# Non-dense (saveat/LinearInterpolation math) and dense (HermiteInterpolation math)
+# now share a single `SciMLBase.BasicInterpolation` type, so re-solving the same problem
+# with different save arguments does not change the solution type. This is what
+# lets code hold a concretely-typed Sundials solution field across re-solves
+# (e.g. GaussAdjoint checkpointing).
+@testset "Solution type invariance across dense/non-dense" begin
+    for alg in (CVODE_BDF(), CVODE_Adams(), ARKODE())
+        sol_dense = solve(
+            prob_ode_linear, alg; dense = true,
+            abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        sol_saveat = solve(
+            prob_ode_linear, alg; saveat = 0.1,
+            abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        sol_nondense = solve(
+            prob_ode_linear, alg; dense = false,
+            abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        @test typeof(sol_dense) == typeof(sol_saveat)
+        @test typeof(sol_dense) == typeof(sol_nondense)
+        @test sol_dense.interp isa SciMLBase.BasicInterpolation
+        @test sol_saveat.interp isa SciMLBase.BasicInterpolation
+        # the runtime dense branch must not degrade inference in either mode
+        @inferred sol_dense(0.5)
+        @inferred sol_saveat(0.5)
+        @inferred sol_dense(0.5, Val{1})
+        @inferred sol_saveat(0.5, Val{1})
+    end
+end
+
+# Piecewise-linear interpolation (non-dense) must reproduce the saved node values
+# exactly and interpolate linearly between them, matching the previous
+# LinearInterpolation behavior.
+@testset "Non-dense linear interpolation correctness" begin
+    for alg in (CVODE_BDF(), CVODE_Adams(), ARKODE())
+        sol = solve(
+            prob_ode_linear, alg; saveat = 0.1,
+            abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        # exact at the saved nodes
+        for (t, u) in zip(sol.t, sol.u)
+            @test sol(t) ≈ u
+        end
+        # linear midpoint between two saved nodes
+        tm = (sol.t[2] + sol.t[3]) / 2
+        @test sol(tm) ≈ (sol.u[2] + sol.u[3]) / 2 rtol = 1.0e-12
+        # deriv = piecewise constant slope over the interval
+        slope = (sol.u[3] - sol.u[2]) / (sol.t[3] - sol.t[2])
+        @test sol(tm, Val{1}) ≈ slope rtol = 1.0e-12
+    end
+end
+
+# Dense (Hermite) interpolation must still match the closed-form solution well
+# and support first-derivative interpolation.
+@testset "Dense Hermite interpolation correctness" begin
+    for alg in (CVODE_BDF(), CVODE_Adams(), ARKODE())
+        sol = solve(
+            prob_ode_linear, alg; dense = true,
+            abstol = 1.0e-8, reltol = 1.0e-8
+        )
+        u0 = sol.u[1]
+        p = sol.prob.p
+        for t in 0.05:0.1:0.95
+            @test sol(t) ≈ u0 * exp(p * t) rtol = 1.0e-4
+            @test sol(t, Val{1}) ≈ p * u0 * exp(p * t) rtol = 1.0e-3
+        end
+    end
+end
+
+# IDA (DAE) solutions must satisfy the same type invariance.
+@testset "IDA solution type invariance" begin
+    # trivial index-1 DAE: u1' = -u1, 0 = u2 - u1
+    function daef(out, du, u, p, t)
+        out[1] = du[1] + u[1]
+        out[2] = u[2] - u[1]
+        return
+    end
+    u0 = [1.0, 1.0]
+    du0 = [-1.0, -1.0]
+    daeprob = DAEProblem(daef, du0, u0, (0.0, 1.0); differential_vars = [true, false])
+    sol_dense = solve(daeprob, IDA(); dense = true, abstol = 1.0e-8, reltol = 1.0e-8)
+    sol_saveat = solve(daeprob, IDA(); saveat = 0.1, abstol = 1.0e-8, reltol = 1.0e-8)
+    @test typeof(sol_dense) == typeof(sol_saveat)
+    @test sol_dense.interp isa SciMLBase.BasicInterpolation
+    for t in 0.05:0.1:0.95
+        @test sol_dense(t)[1] ≈ exp(-t) rtol = 1.0e-4
+    end
+end


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

**SciML/SciMLBase.jl#1436 is merged; merge order now: SciML/SciMLBase.jl#1437 (zero-alloc/FindFirstFunctions follow-up) → SciMLBase release (>= 3.35.0, the first release shipping `BasicInterpolation`) → this PR. CI here will not resolve until that release is out.**

## Problem

Sundials' common interface builds solutions with `SciMLBase.LinearInterpolation` (saveat / non-dense) or `SciMLBase.HermiteInterpolation` (dense). This means re-solving the same problem with different save arguments changes the solution's concrete **type**:

```julia
typeof(solve(prob, CVODE_BDF(); saveat = ts)) != typeof(solve(prob, CVODE_BDF(); dense = true))
```

That breaks any code that holds a concretely-typed Sundials solution field and reassigns it across re-solves. Concretely, it breaks SciMLSensitivity's `GaussAdjoint` checkpointing: the `GaussIntegrand` struct stores the forward solution in a concretely-typed field, but its dense checkpoint re-solves produce a `HermiteInterpolation`-typed `ODESolution` that cannot be assigned back over the original `LinearInterpolation`-typed solution (`setproperty!` `MethodError` converting one `ODESolution{...}` to the other).

## Fix

Switches all three `build_solution` sites (CVODE, ARKODE, IDA) to `SciMLBase.BasicInterpolation`, the runtime-switched fallback interpolation added in SciML/SciMLBase.jl#1436: a single concrete type storing `t, u, du, dense::Bool, sensitivitymode::Bool` that switches between cubic Hermite (dense) and piecewise linear (non-dense) behavior at **runtime** via the `dense` field, rather than by type.

Key invariant (documented with the type in SciMLBase): the derivative timeseries `du` is always the same container type (an empty `Vector` when the solve is not dense), so the concrete `BasicInterpolation` — and therefore the whole solution — has an **identical concrete type** whether or not the solve was dense.

The interpolation math is unchanged: `BasicInterpolation` delegates to SciMLBase's `HermiteInterpolation` / `LinearInterpolation` interpolants, so results are byte-for-byte identical to before.

No Sundials-local interpolation type or glue remains — an earlier revision of this PR carried a local `SundialsInterpolation`; that has moved to SciMLBase as `BasicInterpolation` per maintainer direction so any solver wrapper can use it.

## Versioning

Bumps `6.3.0` -> `6.4.0` (minor). User code that dispatched on the previous `ODESolution{...,LinearInterpolation,...}` / `...HermiteInterpolation...` interp type from Sundials is affected, so this is not a patch. SciMLBase compat floor raised to `3.35` (the first release to ship `BasicInterpolation`; master was reset to the last registered 3.34.0 after the merge).

## Tests

`test/interpolation.jl` adds:
- **Type invariance**: `typeof(solve(prob; dense=true)) == typeof(solve(prob; saveat=...)) == typeof(solve(prob; dense=false))` for CVODE_BDF, CVODE_Adams, ARKODE, and IDA.
- **Non-dense linear correctness**: exact at saved nodes, linear at midpoints, piecewise-constant first derivative.
- **Dense Hermite correctness**: matches the closed-form solution and its first derivative.

Local test results with the SciMLBase#1436 branch dev'd (Julia 1.10): interpolation tests 123/123 plus the pre-existing regression tests, `common_interface/cvode` 33/33, `common_interface/ida` 24 pass / 6 pre-existing broken. The SciMLSensitivity#1541 `sundials_adjoint.jl` regression suite (all three branches dev'd together) passes 32/32 including `GaussAdjoint with CVODE_BDF` 4/4 — see the comment below for full output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrfZy7xBqQLgTqok5zGAdY