### PR TITLE
Allow LinearSolve v4 and v5 (compat bump)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "6.4.0"
+version = "6.4.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -37,7 +37,7 @@ ForwardDiff = "0.10"
 IncompleteLU = "0.2"
 Libdl = "1"
 LinearAlgebra = "1"
-LinearSolve = "3.40.0"
+LinearSolve = "3.40.0, 4, 5"
 Logging = "1"
 ModelingToolkit = "11"
 NonlinearSolveBase = "1.16, 2"


### PR DESCRIPTION
## Summary

Widen Sundials' `LinearSolve` compat from `"3.40.0"` (LinearSolve 3.x only) to `"3.40.0, 4, 5"`, so it admits LinearSolve **4.x and 5.x** in addition to 3.x. This unblocks the SciML stack's move to LinearSolve 4/5 (e.g. NonlinearSolve's Wrappers CI can't resolve when a downstream requires LinearSolve ≥ 4 while Sundials caps it at 3).

## What LinearSolve API does Sundials use? → Pure compat bump, no code changes

Sundials.jl's **only** use of LinearSolve.jl is:

```julia
import LinearSolve # Required for initialization
```

in `src/Sundials.jl`. A full grep of `src/` and `test/` confirms Sundials does **not** touch any LinearSolve solver API — no `LinearProblem`, no `init`/`solve!` on a `LinearCache`, no `*Factorization` algorithms, no `LinearSolveFunction`. All the `LinearSolver` symbols in the source are Sundials' *own* internal SUNLinearSolver type parameters (`Dense`, `Band`, `SPGMR`, `KLU`, …), unrelated to LinearSolve.jl. Sundials' linear solves go through the Sundials C library's `SUNLinearSolver` bindings, not LinearSolve.jl.

Because of this, the known breaking changes across LinearSolve majors do not affect Sundials:

- **3 → 4:** no LinearSolve solver API is used, so nothing to adapt.
- **4 → 5:** LinearSolve 5.0 (SciML/LinearSolve.jl#1083) stopped populating the `cache` field of the returned `LinearSolution` (`solve!(cache)`'s result no longer carries `.cache`) — the migration OrdinaryDiffEq did in SciML/OrdinaryDiffEq.jl#3875. **Sundials never reads `.cache` off a solve result** (verified: zero `.cache` reads in `src/`), so this change is a no-op here.

Hence this is a **pure compat bump** — no source changes required. The only diff is `Project.toml` (`LinearSolve` compat + a patch version bump `6.4.0 → 6.4.1`).

**SciMLBase:** LinearSolve `4.3–5` require `SciMLBase = "3.32"` (i.e. ≥ 3.32). Sundials already pins `SciMLBase = "3.35"` (≥ 3.35), a subset — so no SciMLBase widening is needed.

## Local verification (Julia 1.10.11)

All runs use a stiff Robertson ODE via `CVODE_BDF()` plus a representative core subset of Sundials' own test suite.

### LinearSolve 3.x (regression check — highest 3.x resolvable with SciMLBase 3.35 is 3.87.0)
```
Sundials => 6.4.1, SciMLBase => 3.35.1, LinearSolve => 3.87.0
retcode = Success
u[end]  = [0.01786589987521367, 7.274742816680587e-8, 0.9821340273771606]
```
No regression. (Note: with the compat floor `3.40.0`, the resolver already selected 3.87.0 both before and after this change — behavior on 3.x is unchanged.)

### LinearSolve 4.3.0 (added, registered)
```
Sundials => 6.4.1, SciMLBase => 3.35.1, LinearSolve => 4.3.0, NonlinearSolveBase => 2.33.0
Precompiles: ✓ Sundials
retcode = Success
u[end]  = [0.01786589987521367, 7.274742816680587e-8, 0.9821340273771606]
```
Core test suite (Roberts CVODE/IDA/ARKStep, Kinsol, common_interface CVODE/IDA/ARKODE/Jacobians/Preconditioners): **all pass** (66/66 test items; the lone "error" in one batch run was a scratch-env missing a direct dep declaration for `SciMLBase`/`DiffEqBase`, not a LinearSolve issue — re-running `common_interface/ida.jl` with those declared passes).

### LinearSolve 5.0.0 (added, registered)
```
Sundials => 6.4.1, SciMLBase => 3.35.1, LinearSolve => 5.0.0, SciMLOperators => 1.24.0
Precompiles: ✓ Sundials (incl. NonlinearSolveBaseLinearSolveExt against LS5)
retcode = Success
u[end]  = [0.01786589987521367, 7.274742816680587e-8, 0.9821340273771606]
```

## Upstream note for LinearSolve 5 (not a Sundials issue)

Resolving Sundials + LinearSolve **5.0.0** against the *current registry* fails — but the block is **upstream of Sundials**, not caused by Sundials' compat. `NonlinearSolveBase` (which Sundials depends on for KINSOL) ships a `NonlinearSolveBaseLinearSolveExt` whose weak-compat caps LinearSolve at **4**:

- `NonlinearSolveBase 2.32–2` → weak_compat `LinearSolve = "3.48.0 - 4"`
- Even NonlinearSolveBase **master** (unreleased 2.34.0) still has `LinearSolve = "3.48, 4"`.

So **no registered package in the NonlinearSolve stack admits LinearSolve 5 yet** — this is the exact ecosystem-wide ceiling this PR is meant to help lift. To *prove* Sundials' own code is LinearSolve-5-clean, the LinearSolve 5.0.0 verification above was run with a one-line local patch to NonlinearSolveBase's weak-compat (`"3.48, 4"` → `"3.48, 4, 5"`) — the same one-line bump that needs to land upstream in NonlinearSolveBase. With that in place, Sundials resolves, precompiles, and solves on LinearSolve 5.0.0. Once NonlinearSolveBase releases LinearSolve-5 weak-compat, Sundials picks up 5.x automatically with **no further Sundials change** thanks to this compat widening.

## Impact

Unblocks the SciML stack's move to LinearSolve 4/5 (e.g. NonlinearSolve wrappers CI): downstream packages that require LinearSolve ≥ 4 can now co-resolve with Sundials.

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
