### PR TITLE
Remove Intel Mac CI from test matrix

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -28,7 +28,6 @@ jobs:
         os:
           - "ubuntu-latest"
           - "windows-latest"
-          - "macOS-15-intel"
         arch:
           - "x64"
         include:


### PR DESCRIPTION
Removes the \`macOS-15-intel\` runner from the CI test matrix in \`.github/workflows/Tests.yml\`.

The Apple Silicon Mac runner (\`macOS-latest\`, \`aarch64\`) is retained; only the Intel x64 Mac job is dropped.

Remaining test matrix:
- \`ubuntu-latest\` (x64) — versions \`1\`, \`min\`, \`pre\`
- \`windows-latest\` (x64) — version \`1\`
- \`macOS-latest\` (aarch64) — version \`1\`

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)