### PR TITLE
Release prep: batched version bump for 1 package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "6.4.1"
+version = "6.4.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

Sundials.jl's `lib/` directory contains only auxiliary source files (`libsundials_api.jl`, `libsundials_common.jl`), not separately-registered subpackages with their own `Project.toml`. So this repo has a single registrable package (root `Sundials`) and no internal dependency graph / compat-cascade to check.

**Last registered version**: 6.4.1, registered at commit `8c42234` (tree-sha `b6133c3d08e6dc4eab5875ed11ed42314e9b4cf5`, matching General's `S/Sundials/Versions.toml`).

**Unreleased change since then** (`8c42234` -> `a1f3242`, current default-branch HEAD): one commit, "Remove Intel Mac CI from test matrix (#551)" — deletes `macOS-15-intel` from the CI test matrix in `.github/workflows/Tests.yml`. CI-config-only, no source or behavior change.

Classified **SAFE** (CI/test scaffolding change per the routine-release criteria) -> **patch** release (no new public API).

## Package released

| Package | Old | New | Reason |
|---|---|---|---|
| Sundials (root) | 6.4.1 | 6.4.2 | Own change: CI test-matrix cleanup (SAFE, no source/behavior change) |

No sibling packages exist in this repo to cascade compat floors to.

## Test plan
- [x] Diffed current default-branch HEAD against the commit whose tree-sha matches the last registered version in General, scoped to the change itself
- [x] Confirmed the only change is CI config (no source diff)
- [x] Confirmed no lib/* subpackages exist that would need compat-floor cascades