### PR TITLE
Release 6.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "6.6.0"
+version = "6.5.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Sets the version to 6.5.0 so the accumulated master changes can actually be registered.

| | version |
|---|---|
| registry latest | 6.4.2 |
| master before | 6.6.0 |
| this PR | **6.5.0** |

`6.5.0` was never registered — General goes `… 6.4.0, 6.4.1, 6.4.2` and stops. AutoMerge only accepts the next patch, minor or major, so `6.6.0` would be refused with *"version 6.6.0 skips over 6.5.0"*. Since 6.5.0 never shipped, nobody depends on it and renumbering costs nothing.