### PR TITLE
compat: declare SciMLTesting 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,9 +53,11 @@ SparseConnectivityTracer = "1"
 Sundials_jll = "7.4.1"
 SymbolicIndexingInterface = "0.3.35"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
 DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ SparseConnectivityTracer = "1"
 Sundials_jll = "7.4.1"
 SymbolicIndexingInterface = "0.3.35"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary

Declare the missing SciMLTesting compatibility bound as 2.10 and add its UUID to package test extras in the affected manifest(s):

- Project.toml

This PR is manifest-only. It does not change source behavior, tests, public APIs, or documentation.

## Verification

- Julia TOML.parsefile passed for all TOML files in the 20-repository batch.
- Pkg.Types.read_project passed for all 32 changed manifests, including the new compat and extras entries.
- git diff --check passed for all 20 repositories.
- typos passed on all changed TOML files.
- Runic was not run because the diff contains TOML only.
- No test suite was run because no source or test files changed.

Please ignore this draft until reviewed by @ChrisRackauckas.