### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,9 +53,11 @@ SparseConnectivityTracer = "1"
 Sundials_jll = "7.4.1"
 SymbolicIndexingInterface = "0.3.35"
 Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
 DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ SparseConnectivityTracer = "1"
 Sundials_jll = "7.4.1"
 SymbolicIndexingInterface = "0.3.35"
 Test = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.