### PR TITLE
Add 32-bit (x86) CI lane on Ubuntu

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -40,6 +40,9 @@ jobs:
           - version: "pre"
             os: "ubuntu-latest"
             arch: "x64"
+          - version: "1"
+            os: "ubuntu-latest"
+            arch: "x86"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: ${{ matrix.version }}


### PR DESCRIPTION
## Summary
- Add an Ubuntu arch x86 matrix cell so Sundials runs under 32-bit Julia via SciML/.github @v1.

## Test plan
- [ ] CI shows an x86 Tests job
- [ ] Job green or documents a real 32-bit/native issue
