### PR TITLE
Release Sundials 6.7.1 (32-bit NVector fix)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sundials"
 uuid = "c3572dad-4567-51f8-b174-8c6c989267f4"
-version = "6.7.0"
+version = "6.7.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary
- Version bump only: register the already-merged NVector `Int32` → `sunindextype` fix from #567.
- Unblocks SBMLToolkit / DiffEqParamEstim / ModelingToolkit and other packages still failing x86 against registry 6.7.0.

## Test plan
- [ ] TagBot / JuliaRegistrator produces Sundials v6.7.1
- [ ] Downstream x86 lanes that depended on URL `[sources]` can drop them after registry propagates


Made with [Cursor](https://cursor.com)