### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,57 @@
+using Sundials, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# =============================================================================
+# CVODE solves
+# =============================================================================
+
+SUITE["cvode"] = BenchmarkGroup()
+
+function lorenz!(du, u, p, t)
+    du[1] = 10.0 * (u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+    return nothing
+end
+ode_prob = ODEProblem(lorenz!, [1.0, 0.0, 0.0], (0.0, 30.0))
+
+SUITE["cvode"]["bdf"] = @benchmarkable solve($ode_prob, CVODE_BDF())
+SUITE["cvode"]["adams"] = @benchmarkable solve($ode_prob, CVODE_Adams())
+SUITE["cvode"]["bdf_densejac"] = @benchmarkable solve(
+    $ode_prob, CVODE_BDF(; linear_solver = :Dense)
+)
+
+# =============================================================================
+# ARKODE
+# =============================================================================
+
+SUITE["arkode"] = BenchmarkGroup()
+
+SUITE["arkode"]["explicit"] = @benchmarkable solve(
+    $ode_prob, ARKODE(Sundials.Explicit())
+)
+SUITE["arkode"]["implicit"] = @benchmarkable solve(
+    $ode_prob, ARKODE(Sundials.Implicit())
+)
+
+# =============================================================================
+# IDA (DAE)
+# =============================================================================
+
+SUITE["ida"] = BenchmarkGroup()
+
+function dae_robertson!(resid, du, u, p, t)
+    resid[1] = du[1] + 0.04 * u[1] - 1.0e4 * u[2] * u[3]
+    resid[2] = du[2] - 0.04 * u[1] + 1.0e4 * u[2] * u[3] + 3.0e7 * u[2]^2
+    resid[3] = u[1] + u[2] + u[3] - 1.0
+    return nothing
+end
+u0_dae = [1.0, 0.0, 0.0]
+du0_dae = [-0.04, 0.04, 0.0]
+dae_prob = DAEProblem(
+    dae_robertson!, du0_dae, u0_dae, (0.0, 10.0);
+    differential_vars = [true, true, false]
+)
+
+SUITE["ida"]["robertson"] = @benchmarkable solve($dae_prob, IDA())


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~39s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~39s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md