### PR TITLE
Add regression tests for issues verified fixed in recent releases

### DIFF
--- a/test/common_interface/callbacks.jl
+++ b/test/common_interface/callbacks.jl
@@ -93,3 +93,33 @@ u_out = similar(u₀)
 cb = DiscreteCallback(Returns(true), integ -> integ(@view(u_out[2:2]), integ.t))
 prob = DAEProblem(fbv, du₀, u₀, tspan, p, differential_vars = differential_vars)
 @test_throws ArgumentError solve(prob, IDA(), initializealg = Sundials.BrownFullBasicInit(), callback = cb)
+
+# https://github.com/SciML/Sundials.jl/issues/232
+@testset "ContinuousCallback on matrix state" begin
+    I_ = 6.0
+    function fmat(du, u, p, t)
+        du[1, 1] = -u[1, 1] + I_
+        du[1, 2] = -u[1, 2]
+        du[2, 1] = -0.9 * u[2, 1] + I_
+        return du[2, 2] = -u[2, 2]
+    end
+    u0m = zeros(2, 2)
+    Th = 5.0
+    Reset = 0.0
+    Reset2 = 1.0
+    nfired = Ref(0)
+    conditionm(u, t, integrator) = maximum(u[:, 1]) - Th
+    function affectm!(integrator)
+        nfired[] += 1
+        u = integrator.u
+        maxidx = findmax(u[:, 1])[2]
+        u[maxidx, 1] = Reset
+        u[maxidx, 2] = u[maxidx, 2] + Reset2
+        return nothing
+    end
+    cbm = ContinuousCallback(conditionm, affectm!, nothing)
+    probm = ODEProblem(fmat, u0m, (0.0, 10.0))
+    sol = solve(probm, CVODE_BDF(), callback = cbm)
+    @test sol.retcode == ReturnCode.Success
+    @test nfired[] > 0
+end

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -115,3 +115,16 @@ end
         @test sol_dense(t)[1] ≈ exp(-t) rtol = 1.0e-4
     end
 end
+
+# https://github.com/SciML/Sundials.jl/issues/452
+@testset "IDA saveat derivative continuity" begin
+    dae_f(du, u, p, t) = [du[1] - u[2], u[2] - sin(t)]
+    prob = DAEProblem(
+        DAEFunction(dae_f), [0.0, 0.0], [0.0, 0.0], (0.0, 2pi), nothing;
+        differential_vars = [true, false], abstol = 1.0e-6, reltol = 1.0e-1
+    )
+    sol = solve(prob, IDA(), saveat = 0.01)
+    dvals = Array(sol(sol.t, Val{1}))
+    errs = [abs(dvals[2, i] - cos(sol.t[i])) for i in eachindex(sol.t)]
+    @test maximum(errs) < 0.2
+end


### PR DESCRIPTION
## Summary

Regression tests for issue MWEs confirmed fixed on Sundials v6.7.1 (Julia 1.12.4):

- #232: `ContinuousCallback` on a matrix-valued state with `CVODE_BDF` — the callback fires and the solve succeeds
- #452: `IDA` with `saveat` — `sol(t, Val{1})` now returns continuous derivatives (max error vs `cos(t)` ≈ 0.047 on a `reltol=1e-1` problem, vs. the sharp discontinuities reported)

#### Test plan

- [x] New testsets pass locally (`ContinuousCallback on matrix state`: 2/2; `IDA saveat derivative continuity`: 1/1)
- [x] Runic formatted

🤖 Generated with Devin (harness: Devin CLI; model: SWE-2 Max). Session transcript (local): /home/crackauc/.local/share/devin/cli/summaries/history_ee18806f575d4e4c.md